### PR TITLE
Parse start command in wings

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -143,13 +144,33 @@ func (s *Server) Context() context.Context {
 	return s.ctx
 }
 
+// parseInvocation parses the start command in the same way we already do in the entrypoint
+// We can use this to set the container command with all variables replaced.
+func parseInvocation(invocation string, envvars map[string]interface{}, memory int64, port int, ip string) (parsed string) {
+	// replace "{{" and "}}" with "${" and "}" respectively
+	invocation = strings.Replace(invocation, "{{", "${", -1)
+	invocation = strings.Replace(invocation, "}}", "}", -1)
+
+	// replaces ${varname} with varval
+	for varname, varval := range envvars {
+		invocation = strings.Replace(invocation, fmt.Sprintf("${%s}", varname), fmt.Sprint(varval), -1)
+	}
+
+	// replace the defaults with their configured values.
+	invocation = strings.Replace(invocation, "${SERVER_PORT}", strconv.Itoa(port), -1)
+	invocation = strings.Replace(invocation, "${SERVER_MEMORY}", strconv.Itoa(int(memory)), -1)
+	invocation = strings.Replace(invocation, "${SERVER_IP}", ip, -1)
+
+	return invocation
+}
+
 // Returns all of the environment variables that should be assigned to a running
 // server instance.
 func (s *Server) GetEnvironmentVariables() []string {
 	out := []string{
 		// TODO: allow this to be overridden by the user.
 		fmt.Sprintf("TZ=%s", config.Get().System.Timezone),
-		fmt.Sprintf("STARTUP=%s", s.Config().Invocation),
+		fmt.Sprintf("STARTUP=%s", parseInvocation(s.Config().Invocation, s.Config().EnvVars, s.MemoryLimit(), s.Config().Allocations.DefaultMapping.Port, s.Config().Allocations.DefaultMapping.Ip)),
 		fmt.Sprintf("SERVER_MEMORY=%d", s.MemoryLimit()),
 		fmt.Sprintf("SERVER_IP=%s", s.Config().Allocations.DefaultMapping.Ip),
 		fmt.Sprintf("SERVER_PORT=%d", s.Config().Allocations.DefaultMapping.Port),

--- a/server/server.go
+++ b/server/server.go
@@ -148,18 +148,18 @@ func (s *Server) Context() context.Context {
 // We can use this to set the container command with all variables replaced.
 func parseInvocation(invocation string, envvars map[string]interface{}, memory int64, port int, ip string) (parsed string) {
 	// replace "{{" and "}}" with "${" and "}" respectively
-	invocation = strings.Replace(invocation, "{{", "${", -1)
-	invocation = strings.Replace(invocation, "}}", "}", -1)
+	invocation = strings.ReplaceAll(invocation, "{{", "${")
+	invocation = strings.ReplaceAll(invocation, "}}", "}")
 
 	// replaces ${varname} with varval
 	for varname, varval := range envvars {
-		invocation = strings.Replace(invocation, fmt.Sprintf("${%s}", varname), fmt.Sprint(varval), -1)
+		invocation = strings.ReplaceAll(invocation, fmt.Sprintf("${%s}", varname), fmt.Sprint(varval))
 	}
 
 	// replace the defaults with their configured values.
-	invocation = strings.Replace(invocation, "${SERVER_PORT}", strconv.Itoa(port), -1)
-	invocation = strings.Replace(invocation, "${SERVER_MEMORY}", strconv.Itoa(int(memory)), -1)
-	invocation = strings.Replace(invocation, "${SERVER_IP}", ip, -1)
+	invocation = strings.ReplaceAll(invocation, "${SERVER_PORT}", strconv.Itoa(port))
+	invocation = strings.ReplaceAll(invocation, "${SERVER_MEMORY}", strconv.Itoa(int(memory)))
+	invocation = strings.ReplaceAll(invocation, "${SERVER_IP}", ip)
 
 	return invocation
 }


### PR DESCRIPTION
Adds a function to parse start commands in wings directly.

Potential to remove the need in the entrypoint to support using `exec` vs `eval`