### PR TITLE
Add Docker disk usage endpoint at /api/system/docker/disk

### DIFF
--- a/environment/docker.go
+++ b/environment/docker.go
@@ -105,3 +105,13 @@ func createDockerNetwork(ctx context.Context, cli *client.Client) error {
 	}
 	return nil
 }
+
+// Gets usage statistics for the Docker Daemon such as disk usage
+func GetDockerUsage(ctx context.Context) (types.DiskUsage, error) {
+	cli, err := Docker()
+	if err != nil {
+		return types.DiskUsage{}, err
+	}
+	disk, err := cli.DiskUsage(ctx, types.DiskUsageOptions{})
+	return disk, err
+}

--- a/router/router.go
+++ b/router/router.go
@@ -59,7 +59,7 @@ func Configure(m *wserver.Manager, client remote.Client) *gin.Engine {
 	protected.POST("/api/update", postUpdateConfiguration)
 	protected.GET("/api/system", getSystemInformation)
 	protected.GET("/api/system/docker/disk", getDockerDiskUsage)
-	protected.PUT("/api/system/docker/image/prune", pruneDockerImages)
+	protected.DELETE("/api/system/docker/image/prune", pruneDockerImages)
 	protected.GET("/api/system/ips", getSystemIps)
 	protected.GET("/api/system/utilization", getSystemUtilization)
 	protected.GET("/api/servers", getAllServers)

--- a/router/router.go
+++ b/router/router.go
@@ -4,7 +4,6 @@ import (
 	"emperror.dev/errors"
 	"github.com/apex/log"
 	"github.com/gin-gonic/gin"
-
 	"github.com/pelican-dev/wings/config"
 	"github.com/pelican-dev/wings/remote"
 	"github.com/pelican-dev/wings/router/middleware"
@@ -53,7 +52,9 @@ func Configure(m *wserver.Manager, client remote.Client) *gin.Engine {
 	// This request does not need the AuthorizationMiddleware as the panel should never call it
 	// and requests are authenticated through a JWT the panel issues to the other daemon.
 	router.POST("/api/transfers", postTransfers)
-	
+
+	router.GET("/api/system/docker/disk", getDockerDiskUsage)
+
 	// All the routes beyond this mount will use an authorization middleware
 	// and will not be accessible without the correct Authorization header provided.
 	protected := router.Use(middleware.RequireAuthorization())

--- a/router/router.go
+++ b/router/router.go
@@ -59,6 +59,7 @@ func Configure(m *wserver.Manager, client remote.Client) *gin.Engine {
 	protected.POST("/api/update", postUpdateConfiguration)
 	protected.GET("/api/system", getSystemInformation)
 	protected.GET("/api/system/docker/disk", getDockerDiskUsage)
+	protected.PUT("/api/system/docker/image/prune", pruneDockerImages)
 	protected.GET("/api/system/ips", getSystemIps)
 	protected.GET("/api/system/utilization", getSystemUtilization)
 	protected.GET("/api/servers", getAllServers)

--- a/router/router.go
+++ b/router/router.go
@@ -53,14 +53,12 @@ func Configure(m *wserver.Manager, client remote.Client) *gin.Engine {
 	// and requests are authenticated through a JWT the panel issues to the other daemon.
 	router.POST("/api/transfers", postTransfers)
 
-	router.GET("/api/system/docker/disk", getDockerDiskUsage)
-
 	// All the routes beyond this mount will use an authorization middleware
 	// and will not be accessible without the correct Authorization header provided.
 	protected := router.Use(middleware.RequireAuthorization())
 	protected.POST("/api/update", postUpdateConfiguration)
-
 	protected.GET("/api/system", getSystemInformation)
+	protected.GET("/api/system/docker/disk", getDockerDiskUsage)
 	protected.GET("/api/system/ips", getSystemIps)
 	protected.GET("/api/system/utilization", getSystemUtilization)
 	protected.GET("/api/servers", getAllServers)

--- a/router/router_system.go
+++ b/router/router_system.go
@@ -74,6 +74,16 @@ func getDockerDiskUsage(c *gin.Context) {
 	c.JSON(http.StatusOK, d)
 }
 
+// Prunes the docker image cache
+func pruneDockerImages(c *gin.Context) {
+	p, err := system.PruneDockerImages(c)
+	if err != nil {
+		middleware.CaptureAndAbort(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, p)
+}
+
 // Returns all the servers that are registered and configured correctly on
 // this wings instance.
 func getAllServers(c *gin.Context) {

--- a/router/router_system.go
+++ b/router/router_system.go
@@ -64,6 +64,16 @@ func getSystemUtilization(c *gin.Context) {
 	c.JSON(http.StatusOK, u)
 }
 
+// Returns docker disk utilization
+func getDockerDiskUsage(c *gin.Context) {
+	d, err := system.GetDockerDiskUsage(c)
+	if err != nil {
+		middleware.CaptureAndAbort(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, d)
+}
+
 // Returns all the servers that are registered and configured correctly on
 // this wings instance.
 func getAllServers(c *gin.Context) {

--- a/system/system.go
+++ b/system/system.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"context"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/go-units"
 	"net"
 	"runtime"
@@ -243,6 +244,21 @@ func GetDockerDiskUsage(ctx context.Context) (*DockerDiskUsage, error) {
 		ContainersSize: units.HumanSize(float64(cs)),
 		BuildCacheSize: bcs,
 	}, nil
+}
+
+func PruneDockerImages(ctx context.Context) (types.ImagesPruneReport, error) {
+	// TODO: find a way to re-use the client from the docker environment.
+	c, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return types.ImagesPruneReport{}, err
+	}
+	defer c.Close()
+
+	prune, err := c.ImagesPrune(ctx, filters.Args{})
+	if err != nil {
+		return types.ImagesPruneReport{}, err
+	}
+	return prune, nil
 }
 
 func GetDockerInfo(ctx context.Context) (types.Version, system.Info, error) {

--- a/system/system.go
+++ b/system/system.go
@@ -3,7 +3,6 @@ package system
 import (
 	"context"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/go-units"
 	"net"
 	"runtime"
 
@@ -80,11 +79,11 @@ type Utilization struct {
 }
 
 type DockerDiskUsage struct {
-	ContainersSize string `json:"containers_size"`
-	ImagesTotal    int    `json:"images_total"`
-	ImagesActive   int64  `json:"images_active"`
-	ImagesSize     string `json:"images_size"`
-	BuildCacheSize int64  `json:"build_cache_size"`
+	ContainersSize int64 `json:"containers_size"`
+	ImagesTotal    int   `json:"images_total"`
+	ImagesActive   int64 `json:"images_active"`
+	ImagesSize     int64 `json:"images_size"`
+	BuildCacheSize int64 `json:"build_cache_size"`
 }
 
 func GetSystemInformation() (*Information, error) {
@@ -240,8 +239,8 @@ func GetDockerDiskUsage(ctx context.Context) (*DockerDiskUsage, error) {
 	return &DockerDiskUsage{
 		ImagesTotal:    len(d.Images),
 		ImagesActive:   a,
-		ImagesSize:     units.HumanSize(float64(d.LayersSize)),
-		ContainersSize: units.HumanSize(float64(cs)),
+		ImagesSize:     int64(d.LayersSize),
+		ContainersSize: int64(cs),
 		BuildCacheSize: bcs,
 	}, nil
 }

--- a/system/system.go
+++ b/system/system.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"context"
+	"github.com/docker/go-units"
 	"net"
 	"runtime"
 
@@ -75,6 +76,14 @@ type Utilization struct {
 	CpuPercent  float64 `json:"cpu_percent"`
 	DiskTotal   uint64  `json:"disk_total"`
 	DiskUsed    uint64  `json:"disk_used"`
+}
+
+type DockerDiskUsage struct {
+	ContainersSize string `json:"containers_size"`
+	ImagesTotal    int    `json:"images_total"`
+	ImagesActive   int64  `json:"images_active"`
+	ImagesSize     string `json:"images_size"`
+	BuildCacheSize int64  `json:"build_cache_size"`
 }
 
 func GetSystemInformation() (*Information, error) {
@@ -192,6 +201,47 @@ func GetSystemUtilization() (*Utilization, error) {
 		LoadAvg15:   l.Load15,
 		DiskTotal:   d.Total,
 		DiskUsed:    d.Used,
+	}, nil
+}
+
+func GetDockerDiskUsage(ctx context.Context) (*DockerDiskUsage, error) {
+	// TODO: find a way to re-use the client from the docker environment.
+	c, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return &DockerDiskUsage{}, err
+	}
+	defer c.Close()
+
+	d, err := c.DiskUsage(ctx, types.DiskUsageOptions{})
+	if err != nil {
+		return &DockerDiskUsage{}, err
+	}
+
+	var bcs int64
+	for _, bc := range d.BuildCache {
+		if !bc.Shared {
+			bcs += bc.Size
+		}
+	}
+
+	var a int64
+	for _, i := range d.Images {
+		if i.Containers > 0 {
+			a++
+		}
+	}
+
+	var cs int64
+	for _, b := range d.Containers {
+		cs += b.SizeRootFs
+	}
+
+	return &DockerDiskUsage{
+		ImagesTotal:    len(d.Images),
+		ImagesActive:   a,
+		ImagesSize:     units.HumanSize(float64(d.LayersSize)),
+		ContainersSize: units.HumanSize(float64(cs)),
+		BuildCacheSize: bcs,
 	}, nil
 }
 


### PR DESCRIPTION
/api/system/docker/disk endpoint provides disk utilization of the docker daemon.  Example output:

```
$ curl localhost:8080/api/system/docker/disk
{"containers_size": "163.4MB", "images_total":4,"images_active":2,"images_size":"181MB","build_cache_size":0}
```