### PR TITLE
Dropping "sys_ptrace" capability.

### DIFF
--- a/environment/docker/container.go
+++ b/environment/docker/container.go
@@ -252,6 +252,7 @@ func (e *Environment) Create() error {
 		CapDrop: []string{
 			"setpcap", "mknod", "audit_write", "net_raw", "dac_override",
 			"fowner", "fsetid", "net_bind_service", "sys_chroot", "setfcap",
+			"sys_ptrace",
 		},
 		NetworkMode: networkMode,
 		UsernsMode:  container.UsernsMode(cfg.Docker.UsernsMode),


### PR DESCRIPTION
`proot` is a program known for its usage in creating unprivileged chroots.
This program essentially gives the user the capability create a chroot into another system without any permissions, effectively turning the container into a "server" - which is not an intended use for a container.

However, this program relies on a unprivileged system call in Linux systems known as `ptrace`, and by disabling it, scripts such as PteroVM or any of its derivatives will be rendered useless.

Before merging, please conduct some tests as this might cause potential break in some eggs (maybe?)