### PR TITLE
fix actions artifacts

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -62,14 +62,14 @@ jobs:
 
       - name: Upload Release Artifact
         uses: actions/upload-artifact@v4
-        if: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && matrix.go == '1.21.8' }}
+        if: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && matrix.go == '1.21.9' }}
         with:
           name: wings_linux_${{ matrix.goarch }}
           path: dist/wings
 
       - name: Upload Debug Artifact
         uses: actions/upload-artifact@v4
-        if: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && matrix.go == '1.21.8' }}
+        if: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && matrix.go == '1.21.9' }}
         with:
           name: wings_linux_${{ matrix.goarch }}_debug
           path: dist/wings_debug


### PR DESCRIPTION
# Description

Because we bumpt the go version to 1.21.9 and those 2 lines were not changed so there are no artifacts anymore to the actions attached