### PR TITLE
Allow to specify the server Timezone at egg level

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -211,7 +211,6 @@ func parseInvocation(invocation string, envvars map[string]interface{}, memory i
 // server instance.
 func (s *Server) GetEnvironmentVariables() []string {
 	out := []string{
-		// TODO: allow this to be overridden by the user.
 		fmt.Sprintf("TZ=%s", DetermineServerTimezone(s.Config().EnvVars, config.Get().System.Timezone)),
 		fmt.Sprintf("STARTUP=%s", parseInvocation(s.Config().Invocation, s.Config().EnvVars, s.MemoryLimit(), s.Config().Allocations.DefaultMapping.Port, s.Config().Allocations.DefaultMapping.Ip)),
 		fmt.Sprintf("SERVER_MEMORY=%d", s.MemoryLimit()),

--- a/server/server.go
+++ b/server/server.go
@@ -6,10 +6,11 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
-	"regexp"
+	"time"
 
 	"emperror.dev/errors"
 	"github.com/apex/log"
@@ -146,6 +147,25 @@ func (s *Server) Context() context.Context {
 	return s.ctx
 }
 
+// DetermineServerTimezone checks the envvars for a non-empty SERVER_TIMEZONE key,
+// validates if it's a valid timezone, and returns it. If not, returns the defaultTimezone.
+func DetermineServerTimezone(envvars map[string]interface{}, defaultTimezone string) string {
+	// Check if SERVER_TIMEZONE exists in envvars and is non-empty
+	timezone, ok := envvars["SERVER_TIMEZONE"].(string)
+	if ok && timezone != "" {
+		// Validate the timezone
+		_, err := time.LoadLocation(timezone)
+		if err == nil {
+			// Valid timezone, return it
+			return timezone
+		}
+		// Invalid timezone, fall through to return defaultTimezone
+	}
+
+	// Return the defaultTimezone if SERVER_TIMEZONE is not set, empty, or invalid
+	return defaultTimezone
+}
+
 // parseInvocation parses the start command in the same way we already do in the entrypoint
 // We can use this to set the container command with all variables replaced.
 func parseInvocation(invocation string, envvars map[string]interface{}, memory int64, port int, ip string) (parsed string) {
@@ -192,7 +212,7 @@ func parseInvocation(invocation string, envvars map[string]interface{}, memory i
 func (s *Server) GetEnvironmentVariables() []string {
 	out := []string{
 		// TODO: allow this to be overridden by the user.
-		fmt.Sprintf("TZ=%s", config.Get().System.Timezone),
+		fmt.Sprintf("TZ=%s", DetermineServerTimezone(s.Config().EnvVars, config.Get().System.Timezone)),
 		fmt.Sprintf("STARTUP=%s", parseInvocation(s.Config().Invocation, s.Config().EnvVars, s.MemoryLimit(), s.Config().Allocations.DefaultMapping.Port, s.Config().Allocations.DefaultMapping.Ip)),
 		fmt.Sprintf("SERVER_MEMORY=%d", s.MemoryLimit()),
 		fmt.Sprintf("SERVER_IP=%s", s.Config().Allocations.DefaultMapping.Ip),


### PR DESCRIPTION
# Changes

- Allow a server to set a time zone that is not the same as the one in that wings config
- This is done with the env variable `SERVER_TIMEZONE` 
- If it does not exist then it will use the time zone out of the wings config
- if it exists but is empty it will still use the wings config one
- if it exists it does a check with the time library if it is a valid timezone, if it is it sets it to the TZ variable if not it falls back to the wings config one

This maybe not that useful for now (for some it will), but if the panel add-ons feature is there you can just make a fancy UI for it

# Screenshots
## ENV variable does not exist 
![NO_ENV](https://github.com/pelican-dev/wings/assets/67589015/d79d2033-c4a1-4cde-bc29-71bb1c9cf317)
## ENV exist but is empty
![ENV_EMPTY](https://github.com/pelican-dev/wings/assets/67589015/fe0e4ca6-9a13-43e6-937f-bbd30da618da)
## ENV with invalid timezone
![ENV_NOT_VALID](https://github.com/pelican-dev/wings/assets/67589015/098ecc45-9f20-4a4e-8be8-b5d6dfd31064)
## ENV exist with a valid timezone
![ENV_SET_CUSTOM](https://github.com/pelican-dev/wings/assets/67589015/2907dc78-5d13-4974-88d7-f1d1bd2e903a)

