### PR TITLE
Enforce the egg's file denylist more thoroughly

### DIFF
--- a/router/router_download.go
+++ b/router/router_download.go
@@ -89,6 +89,11 @@ func getDownloadFile(c *gin.Context) {
 		return
 	}
 
+	if err := s.Filesystem().IsIgnored(token.FilePath); err != nil {
+		middleware.CaptureAndAbort(c, err)
+		return
+	}
+
 	f, st, err := s.Filesystem().File(token.FilePath)
 	if err != nil {
 		middleware.CaptureAndAbort(c, err)

--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -31,6 +31,10 @@ import (
 func getServerFileContents(c *gin.Context) {
 	s := middleware.ExtractServer(c)
 	p := strings.TrimLeft(c.Query("file"), "/")
+	if err := s.Filesystem().IsIgnored(p); err != nil {
+		middleware.CaptureAndAbort(c, err)
+		return
+	}
 	f, st, err := s.Filesystem().File(p)
 	if err != nil {
 		middleware.CaptureAndAbort(c, err)
@@ -214,6 +218,9 @@ func postServerDeleteFiles(c *gin.Context) {
 			case <-ctx.Done():
 				return ctx.Err()
 			default:
+				if err := s.Filesystem().IsIgnored(pi); err != nil {
+					return err
+				}
 				return s.Filesystem().Delete(pi)
 			}
 		})
@@ -324,7 +331,10 @@ func postServerPullRemoteFile(c *gin.Context) {
 		FileName:  data.FileName,
 		UseHeader: data.UseHeader,
 	})
-
+	if err := s.Filesystem().IsIgnored(dl.Path()); err != nil {
+		middleware.CaptureAndAbort(c, err)
+		return
+	}
 	download := func() error {
 		s.Log().WithField("download_id", dl.Identifier).WithField("url", u.String()).Info("starting pull of remote file to disk")
 		if err := dl.Execute(); err != nil {

--- a/server/filesystem/compress.go
+++ b/server/filesystem/compress.go
@@ -29,6 +29,11 @@ import (
 // and the compressed file will be placed at that location named
 // `archive-{date}.tar.gz`.
 func (fs *Filesystem) CompressFiles(dir string, paths []string) (ufs.FileInfo, error) {
+	for _, file := range paths {
+		if err := fs.IsIgnored(path.Join(dir, file)); err != nil {
+			return nil, err
+		}
+	}
 	a := &Archive{Filesystem: fs, BaseDirectory: dir, Files: paths}
 	d := path.Join(
 		dir,

--- a/server/filesystem/compress.go
+++ b/server/filesystem/compress.go
@@ -31,11 +31,9 @@ import (
 func (fs *Filesystem) CompressFiles(dir string, paths []string) (ufs.FileInfo, error) {
 	var validPaths []string
 	for _, file := range paths {
-		if err := fs.IsIgnored(path.Join(dir, file)); err != nil {
-			// file is in file denylist so skip it and continue to check the next files
-			continue
+		if err := fs.IsIgnored(path.Join(dir, file)); err == nil {
+			validPaths = append(validPaths, file)
 		}
-		validPaths = append(validPaths, file)
 	}
 
 	// If there are no valid paths, return an error

--- a/sftp/handler.go
+++ b/sftp/handler.go
@@ -79,6 +79,9 @@ func (h *Handler) Fileread(request *sftp.Request) (io.ReaderAt, error) {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if err := h.fs.IsIgnored(request.Filepath); err != nil {
+		return nil, err
+	}
 	f, _, err := h.fs.File(request.Filepath)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
@@ -104,6 +107,10 @@ func (h *Handler) Filewrite(request *sftp.Request) (io.WriterAt, error) {
 
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	
+	if err := h.fs.IsIgnored(request.Filepath); err != nil {
+		return nil, err
+	}
 	// The specific permission required to perform this action. If the file exists on the
 	// system already it only needs to be an update, otherwise we'll check for a create.
 	permission := PermissionFileUpdate
@@ -148,6 +155,10 @@ func (h *Handler) Filecmd(request *sftp.Request) error {
 		l = l.WithField("target", request.Target)
 	}
 
+	if err := h.fs.IsIgnored(request.Filepath); err != nil {
+		return err
+	}
+	
 	switch request.Method {
 	// Allows a user to make changes to the permissions of a given file or directory
 	// on their server using their SFTP client.


### PR DESCRIPTION
# Changes

- Files within the file_denylist can not be removed anymore
- Files within that list can not be created anymore:
![afbeelding](https://github.com/pelican-dev/wings/assets/67589015/e59d875a-d0dd-4df3-88f2-59e9582b96bf)
- If the file is put their by for example the egg install script then the user can not see what is in it
- This includes also over SFTP
![afbeelding](https://github.com/pelican-dev/wings/assets/67589015/2b05d0c3-b3df-40c5-9337-13da447363de)
![afbeelding](https://github.com/pelican-dev/wings/assets/67589015/862dc59d-754c-4d0a-b2d9-665253a54674)
- Application (tested by exec in the container) can still read the files just fine
![afbeelding](https://github.com/pelican-dev/wings/assets/67589015/13e27cec-5f79-4882-a5c0-ab1fea9a28da)

