### PR TITLE
Fixes S3 backup error #26 

### DIFF
--- a/server/backup/backup_s3.go
+++ b/server/backup/backup_s3.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -58,6 +59,12 @@ func (s *S3Backup) Generate(ctx context.Context, fsys *filesystem.Filesystem, ig
 	}
 
 	s.log().WithField("path", s.Path()).Info("creating backup for server")
+	if _, err := os.Stat(filepath.Dir(s.Path())); os.IsNotExist(err) {
+		err := os.Mkdir(filepath.Dir(s.Path()), 0o700)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if err := a.Create(ctx, s.Path()); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #26 by adding back mkdir for the temporary archive that gets stored locally before upload to S3

> Tested locally with Minio should work with S3/R2 as the issue is with the temp dir not being made and not the API itself