### PR TITLE
Allow for variables in the configuration parser filename

### DIFF
--- a/server/config_parser.go
+++ b/server/config_parser.go
@@ -3,10 +3,32 @@ package server
 import (
 	"runtime"
 
-	"github.com/gammazero/workerpool"
+	"fmt"
+	"strings"
 
+	"github.com/gammazero/workerpool"
 	"github.com/pelican-dev/wings/internal/ufs"
 )
+
+// Helper function to replace variables in the file path of the configuration parser
+func replaceParserConfigPathVariables(filename string, envvars map[string]interface{}) string {
+	// Check if filename contains at least one '{' and one '}'
+	// This is here for performance as 99% of the eggs configuration parsers do not have variables in its path
+	if !strings.Contains(filename, "{") || !strings.Contains(filename, "}") {
+		return filename
+	}
+
+	// Replace "{{" with "${" and "}}" with "}"
+	filename = strings.ReplaceAll(filename, "{{", "${")
+	filename = strings.ReplaceAll(modifiedFilename, "}}", "}")
+
+	// replaces ${varname} with varval
+	for varname, varval := range envvars {
+		filename = strings.ReplaceAll(filename, fmt.Sprintf("${%s}", varname), fmt.Sprint(varval))
+	}
+
+	return filename
+}
 
 // UpdateConfigurationFiles updates all the defined configuration files for
 // a server automatically to ensure that they always use the specified values.
@@ -20,7 +42,8 @@ func (s *Server) UpdateConfigurationFiles() {
 		f := cf
 
 		pool.Submit(func() {
-			file, err := s.Filesystem().UnixFS().Touch(f.FileName, ufs.O_RDWR|ufs.O_CREATE, 0o644)
+			filename := replaceParserConfigPathVariables(f.filename, s.Config().EnvVars)
+			file, err := s.Filesystem().UnixFS().Touch(filename, ufs.O_RDWR|ufs.O_CREATE, 0o644)
 			if err != nil {
 				s.Log().WithField("file_name", f.FileName).WithField("error", err).Error("failed to open file for configuration")
 				return

--- a/server/config_parser.go
+++ b/server/config_parser.go
@@ -20,7 +20,7 @@ func replaceParserConfigPathVariables(filename string, envvars map[string]interf
 
 	// Replace "{{" with "${" and "}}" with "}"
 	filename = strings.ReplaceAll(filename, "{{", "${")
-	filename = strings.ReplaceAll(modifiedFilename, "}}", "}")
+	filename = strings.ReplaceAll(filename, "}}", "}")
 
 	// replaces ${varname} with varval
 	for varname, varval := range envvars {
@@ -42,7 +42,7 @@ func (s *Server) UpdateConfigurationFiles() {
 		f := cf
 
 		pool.Submit(func() {
-			filename := replaceParserConfigPathVariables(f.filename, s.Config().EnvVars)
+			filename := replaceParserConfigPathVariables(f.FileName, s.Config().EnvVars)
 			file, err := s.Filesystem().UnixFS().Touch(filename, ufs.O_RDWR|ufs.O_CREATE, 0o644)
 			if err != nil {
 				s.Log().WithField("file_name", f.FileName).WithField("error", err).Error("failed to open file for configuration")


### PR DESCRIPTION
# Changes

- This PR should allow having a variable in the filepath in the configuration parser
- closes https://github.com/pelican-dev/panel/discussions/505

# Edit
This works:
![afbeelding](https://github.com/user-attachments/assets/baff0967-80e0-4da7-824f-4c2285c93ace)
![afbeelding](https://github.com/user-attachments/assets/30693996-6546-44f9-b10b-ccafd5c93d77)
