### PR TITLE
run the install script as an entrypoint and not a cmd

### DIFF
--- a/server/install.go
+++ b/server/install.go
@@ -403,7 +403,8 @@ func (ip *InstallationProcess) Execute() (string, error) {
 		AttachStdin:  true,
 		OpenStdin:    true,
 		Tty:          true,
-		Cmd:          []string{ip.Script.Entrypoint, "/mnt/install/install.sh"},
+		Entrypoint:   []string{ip.Script.Entrypoint, "/mnt/install/install.sh"},
+		Cmd:          nil,
 		Image:        ip.Script.ContainerImage,
 		Env:          ip.Server.GetEnvironmentVariables(),
 		Labels: map[string]string{


### PR DESCRIPTION
This change is here for something very specific and not widely tested (yet).

I am making an egg for TiltedEvolution (SkyrimTogetherServer) and to get the server files they get pulled out of the install image as that are the only build server files and building them takes way to long.

The problem is that, that image entrypoint directly launches the game so the install script would never run. This is because we pass it to the cmd argument what runs after the entrypoint but of course that would never exit. 

This PR forces to clear the cmd out of the selected image (if it has set one) and run the install script as the entrypoint. 

edit: this does not work (turning the logic arround)
~~If wanted I could turn this arround and clear the entrypoint field and use the cmd field if wanted~~