### PR TITLE
add File search endpoint

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,20 +91,20 @@ func init() {
 }
 
 func isDockerSnap() bool {
-    cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-    if err != nil {
-        log.Fatalf("Unable to initialize Docker client: %s", err)
-    }
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		log.Fatalf("Unable to initialize Docker client: %s", err)
+	}
 
-    defer cli.Close() // Close the client when the function returns (should not be needed, but just to be safe)
+	defer cli.Close() // Close the client when the function returns (should not be needed, but just to be safe)
 
-    info, err := cli.Info(context.Background())
-    if err != nil {
-        log.Fatalf("Unable to get Docker info: %s", err)
-    }
+	info, err := cli.Info(context.Background())
+	if err != nil {
+		log.Fatalf("Unable to get Docker info: %s", err)
+	}
 
-    // Check if Docker root directory contains '/var/snap/docker'
-    return strings.Contains(info.DockerRootDir, "/var/snap/docker")
+	// Check if Docker root directory contains '/var/snap/docker'
+	return strings.Contains(info.DockerRootDir, "/var/snap/docker")
 }
 
 func rootCmdRun(cmd *cobra.Command, _ []string) {
@@ -401,12 +401,12 @@ func rootCmdRun(cmd *cobra.Command, _ []string) {
 // Reads the configuration from the disk and then sets up the global singleton
 // with all the configuration values.
 func initConfig() {
-	if !strings.HasPrefix(configPath, "/") {
-		d, err := os.Getwd()
+	if !filepath.IsAbs(configPath) {
+		d, err := filepath.Abs(configPath)
 		if err != nil {
-			log2.Fatalf("cmd/root: could not determine directory: %s", err)
+			log2.Fatalf("cmd/root: failed to get path to config file: %s", err)
 		}
-		configPath = path.Clean(path.Join(d, configPath))
+		configPath = d
 	}
 	err := config.FromFile(configPath)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/gbrlsnchs/jwt/v3"
 	"os"
 	"os/exec"
 	"os/user"
@@ -16,6 +15,8 @@ import (
 	"sync/atomic"
 	"text/template"
 	"time"
+
+	"github.com/gbrlsnchs/jwt/v3"
 
 	"emperror.dev/errors"
 	"github.com/acobaugh/osrelease"
@@ -321,6 +322,7 @@ type Configuration struct {
 	// This is required to have the "Server Mounts" feature work properly.
 	AllowedMounts []string `json:"-" yaml:"allowed_mounts"`
 
+	SearchRecursion SearchRecursion `yaml:"Search"`
 	// BlockBaseDirMount indicates whether mounting to /home/container is blocked.
 	// If true, mounting to /home/container is blocked.
 	// If false, mounting to /home/container is allowed.
@@ -339,6 +341,15 @@ type Configuration struct {
 
 	// IgnorePanelConfigUpdates causes confiuration updates that are sent by the panel to be ignored.
 	IgnorePanelConfigUpdates bool `json:"ignore_panel_config_updates" yaml:"ignore_panel_config_updates"`
+}
+
+// SearchRecursion holds the configuration for directory search recursion settings.
+type SearchRecursion struct {
+	// BlacklistedDirs is a list of directory names that should be excluded from the recursion.
+	BlacklistedDirs []string `default:"[\"node_modules\", \".wine\", \"appcache\", \"depotcache\"]" yaml:"blacklisted_dirs" json:"blacklisted_dirs"`
+
+	// MaxRecursionDepth specifies the maximum depth for directory recursion.
+	MaxRecursionDepth int `default:"8" yaml:"max_recursion_depth" json:"max_recursion_depth"`
 }
 
 // NewAtPath creates a new struct and set the path where it should be stored.

--- a/config/config.go
+++ b/config/config.go
@@ -346,7 +346,7 @@ type Configuration struct {
 // SearchRecursion holds the configuration for directory search recursion settings.
 type SearchRecursion struct {
 	// BlacklistedDirs is a list of directory names that should be excluded from the recursion.
-	BlacklistedDirs []string `default:"[\"node_modules\", \".wine\", \"appcache\", \"depotcache\"]" yaml:"blacklisted_dirs" json:"blacklisted_dirs"`
+	BlacklistedDirs []string `default:"[\"node_modules\", \".wine\", \"appcache\", \"depotcache\", \"vendor\"]" yaml:"blacklisted_dirs" json:"blacklisted_dirs"`
 
 	// MaxRecursionDepth specifies the maximum depth for directory recursion.
 	MaxRecursionDepth int `default:"8" yaml:"max_recursion_depth" json:"max_recursion_depth"`

--- a/config/config.go
+++ b/config/config.go
@@ -356,12 +356,7 @@ type SearchRecursion struct {
 // This function does not modify the currently stored global configuration.
 func NewAtPath(path string) (*Configuration, error) {
 	var c Configuration
-	// Configures the default values for many of the configuration options present
-	// in the structs. Values set in the configuration file take priority over the
-	// default values.
-	if err := defaults.Set(&c); err != nil {
-		return nil, err
-	}
+
 	// Track the location where we created this configuration.
 	c.path = path
 	return &c, nil
@@ -534,6 +529,13 @@ func FromFile(path string) error {
 	}
 
 	if err := yaml.Unmarshal(b, c); err != nil {
+		return err
+	}
+
+	// Configures the default values for many of the configuration options present
+	// in the structs. Values set in the configuration file take priority over the
+	// default values.
+	if err := defaults.Set(&c); err != nil {
 		return err
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -356,7 +356,12 @@ type SearchRecursion struct {
 // This function does not modify the currently stored global configuration.
 func NewAtPath(path string) (*Configuration, error) {
 	var c Configuration
-
+	// Configures the default values for many of the configuration options present
+	// in the structs. Values set in the configuration file take priority over the
+	// default values.
+	if err := defaults.Set(&c); err != nil {
+		return nil, err
+	}
 	// Track the location where we created this configuration.
 	c.path = path
 	return &c, nil
@@ -529,13 +534,6 @@ func FromFile(path string) error {
 	}
 
 	if err := yaml.Unmarshal(b, c); err != nil {
-		return err
-	}
-
-	// Configures the default values for many of the configuration options present
-	// in the structs. Values set in the configuration file take priority over the
-	// default values.
-	if err := defaults.Set(&c); err != nil {
 		return err
 	}
 

--- a/router/router.go
+++ b/router/router.go
@@ -102,6 +102,7 @@ func Configure(m *wserver.Manager, client remote.Client) *gin.Engine {
 			files.POST("/compress", postServerCompressFiles)
 			files.POST("/decompress", postServerDecompressFiles)
 			files.POST("/chmod", postServerChmodFile)
+			files.GET("/search", getFilesBySearch)
 
 			files.GET("/pull", middleware.RemoteDownloadEnabled(), getServerPullingFiles)
 			files.POST("/pull", middleware.RemoteDownloadEnabled(), postServerPullRemoteFile)

--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -112,6 +112,60 @@ func appendMatchedEntry(matchedEntries *[]filesystem.Stat, fileInfo ufs.FileInfo
 	})
 }
 
+// Recursive function to search through directories
+func searchDirectory(s *server.Server, dir string, patternLower string, depth int, matchedEntries *[]filesystem.Stat, matchedDirectories *[]string, c *gin.Context) {
+	if depth > 8 {
+		return // Stop recursion if depth exceeds 8
+	}
+
+	stats, err := s.Filesystem().ListDirectory(dir)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"message": "Directory not found"})
+		return
+	}
+
+	for _, fileInfo := range stats {
+		fileName := fileInfo.Name()
+		fileType := fileInfo.Mimetype
+		fileNameLower := strings.ToLower(fileName)
+		fullPath := filepath.Join(dir, fileName)
+
+		// Store directories separately
+		if fileType == "inode/directory" {
+			if strings.Contains(fileNameLower, "node_modules") {
+				continue // Skip blacklisted directories
+			}
+			*matchedDirectories = append(*matchedDirectories, fullPath) // Correctly dereference to append
+
+			// Recursive search in the matched directory
+			searchDirectory(s, fullPath, patternLower, depth+1, matchedEntries, matchedDirectories, c)
+		}
+
+		// Wildcard or exact matching logic
+		if strings.ContainsAny(patternLower, "*?") {
+			if match, _ := filepath.Match(patternLower, fileNameLower); match {
+				appendMatchedEntry(matchedEntries, fileInfo, fullPath, fileType)
+			}
+		} else {
+			// Check for substring matches (case-insensitive)
+			if strings.Contains(fileNameLower, patternLower) {
+				appendMatchedEntry(matchedEntries, fileInfo, fullPath, fileType)
+			} else {
+				// Extension matching logic
+				ext := filepath.Ext(fileNameLower)
+				if strings.HasPrefix(patternLower, ".") || !strings.Contains(patternLower, ".") {
+					// Match extension without dot
+					if strings.TrimPrefix(ext, ".") == strings.TrimPrefix(patternLower, ".") {
+						appendMatchedEntry(matchedEntries, fileInfo, fullPath, fileType)
+					}
+				} else if fileNameLower == patternLower { // Full name match
+					appendMatchedEntry(matchedEntries, fileInfo, fullPath, fileType)
+				}
+			}
+		}
+	}
+}
+
 func getFilesBySearch(c *gin.Context) {
 	s := middleware.ExtractServer(c)
 	dir := strings.TrimSuffix(c.Query("directory"), "/")
@@ -126,55 +180,15 @@ func getFilesBySearch(c *gin.Context) {
 		return
 	}
 
-	// Proceed with directory listing if pattern is valid
-	stats, err := s.Filesystem().ListDirectory(dir)
-	if err != nil {
-		middleware.CaptureAndAbort(c, err)
-		return
-	}
-
 	// Prepare slices to store matched stats and directories
 	matchedEntries := []filesystem.Stat{}
 	matchedDirectories := []string{}
 
-	// Filter filenames and directories based on pattern
-	for _, fileInfo := range stats {
-		fileName := fileInfo.Name()
-		fileType := fileInfo.Mimetype
-		fileNameLower := strings.ToLower(fileName)
-		fullPath := filepath.Join(dir, fileName)
-
-		// Store directories separately
-		if fileType == "inode/directory" {
-			matchedDirectories = append(matchedDirectories, fullPath)
-		}
-
-		// Wildcard or exact matching logic
-		if strings.ContainsAny(patternLower, "*?") {
-			if match, _ := filepath.Match(patternLower, fileNameLower); match {
-				appendMatchedEntry(&matchedEntries, fileInfo, fullPath, fileType)
-			}
-		} else {
-			// Check for prefix matches (case-insensitive)
-			if strings.Contains(fileNameLower, patternLower) {
-				appendMatchedEntry(&matchedEntries, fileInfo, fullPath, fileType)
-			} else {
-				// Extension matching logic
-				ext := filepath.Ext(fileNameLower)
-				if strings.HasPrefix(patternLower, ".") || !strings.Contains(patternLower, ".") {
-					// Match extension without dot
-					if strings.TrimPrefix(ext, ".") == strings.TrimPrefix(patternLower, ".") {
-						appendMatchedEntry(&matchedEntries, fileInfo, fullPath, fileType)
-					}
-				} else if fileNameLower == patternLower { // Full name match
-					appendMatchedEntry(&matchedEntries, fileInfo, fullPath, fileType)
-				}
-			}
-		}
-	}
+	// Start the search from the initial directory
+	searchDirectory(s, dir, patternLower, 0, &matchedEntries, &matchedDirectories, c)
 
 	// Return the matched stats (only those that matched the pattern) and directories separately
-	if len(matchedEntries) == 0 && len(matchedDirectories) == 0 {
+	if len(matchedEntries) == 0 && len(matchedDirectories) != 0 {
 		c.JSON(http.StatusOK, gin.H{"message": "No matches found."})
 	} else {
 		// For debugging purposes

--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -155,16 +155,18 @@ func getFilesBySearch(c *gin.Context) {
 				appendMatchedEntry(&matchedEntries, fileInfo, fullPath, fileType)
 			}
 		} else {
-			// Check for extension or prefix matches
-			if strings.HasPrefix(patternLower, ".") || !strings.Contains(patternLower, ".") {
-				// Extension matching
-				ext := filepath.Ext(fileNameLower)
-				if strings.TrimPrefix(ext, ".") == strings.TrimPrefix(patternLower, ".") {
-					appendMatchedEntry(&matchedEntries, fileInfo, fullPath, fileType)
-				}
+			// Check for prefix matches (case-insensitive)
+			if strings.Contains(fileNameLower, patternLower) {
+				appendMatchedEntry(&matchedEntries, fileInfo, fullPath, fileType)
 			} else {
-				// Full name or prefix matching
-				if strings.HasPrefix(fileNameLower, patternLower) || fileNameLower == patternLower {
+				// Extension matching logic
+				ext := filepath.Ext(fileNameLower)
+				if strings.HasPrefix(patternLower, ".") || !strings.Contains(patternLower, ".") {
+					// Match extension without dot
+					if strings.TrimPrefix(ext, ".") == strings.TrimPrefix(patternLower, ".") {
+						appendMatchedEntry(&matchedEntries, fileInfo, fullPath, fileType)
+					}
+				} else if fileNameLower == patternLower { // Full name match
 					appendMatchedEntry(&matchedEntries, fileInfo, fullPath, fileType)
 				}
 			}

--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -100,6 +100,9 @@ func getFilesBySearch(c *gin.Context) {
 		pattern = "txt"
 	}
 
+	// Trim trailing slash from the directory if present
+	dir = strings.TrimSuffix(dir, "/")
+	
 	// Convert the pattern to lowercase for case-insensitive comparison
 	patternLower := strings.ToLower(pattern)
 

--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -3,7 +3,6 @@ package router
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -21,7 +20,6 @@ import (
 
 	"github.com/pelican-dev/wings/config"
 	"github.com/pelican-dev/wings/internal/models"
-	"github.com/pelican-dev/wings/internal/ufs"
 	"github.com/pelican-dev/wings/router/downloader"
 	"github.com/pelican-dev/wings/router/middleware"
 	"github.com/pelican-dev/wings/router/tokens"
@@ -91,112 +89,6 @@ func getServerListDirectory(c *gin.Context) {
 	}
 }
 
-// Structs needed to respond with the matched files and all their info
-type customFileInfo struct {
-	ufs.FileInfo
-	newName string
-}
-
-func (cfi customFileInfo) Name() string {
-	return cfi.newName // Return the custom name (i.e., with the directory prefix)
-}
-
-// Helper function to append matched entries
-func appendMatchedEntry(matchedEntries *[]filesystem.Stat, fileInfo ufs.FileInfo, fullPath string, fileType string) {
-	*matchedEntries = append(*matchedEntries, filesystem.Stat{
-		FileInfo: customFileInfo{
-			FileInfo: fileInfo,
-			newName:  fullPath,
-		},
-		Mimetype: fileType,
-	})
-}
-
-// Recursive function to search through directories
-func searchDirectory(s *server.Server, dir string, patternLower string, depth int, matchedEntries *[]filesystem.Stat, matchedDirectories *[]string, c *gin.Context) {
-	if depth > 8 {
-		return // Stop recursion if depth exceeds 8
-	}
-
-	stats, err := s.Filesystem().ListDirectory(dir)
-	if err != nil {
-		c.JSON(http.StatusOK, gin.H{"message": "Directory not found"})
-		return
-	}
-
-	for _, fileInfo := range stats {
-		fileName := fileInfo.Name()
-		fileType := fileInfo.Mimetype
-		fileNameLower := strings.ToLower(fileName)
-		fullPath := filepath.Join(dir, fileName)
-
-		// Store directories separately
-		if fileType == "inode/directory" {
-			if strings.Contains(fileNameLower, "node_modules") {
-				continue // Skip blacklisted directories
-			}
-			*matchedDirectories = append(*matchedDirectories, fullPath) // Correctly dereference to append
-
-			// Recursive search in the matched directory
-			searchDirectory(s, fullPath, patternLower, depth+1, matchedEntries, matchedDirectories, c)
-		}
-
-		// Wildcard or exact matching logic
-		if strings.ContainsAny(patternLower, "*?") {
-			if match, _ := filepath.Match(patternLower, fileNameLower); match {
-				appendMatchedEntry(matchedEntries, fileInfo, fullPath, fileType)
-			}
-		} else {
-			// Check for substring matches (case-insensitive)
-			if strings.Contains(fileNameLower, patternLower) {
-				appendMatchedEntry(matchedEntries, fileInfo, fullPath, fileType)
-			} else {
-				// Extension matching logic
-				ext := filepath.Ext(fileNameLower)
-				if strings.HasPrefix(patternLower, ".") || !strings.Contains(patternLower, ".") {
-					// Match extension without dot
-					if strings.TrimPrefix(ext, ".") == strings.TrimPrefix(patternLower, ".") {
-						appendMatchedEntry(matchedEntries, fileInfo, fullPath, fileType)
-					}
-				} else if fileNameLower == patternLower { // Full name match
-					appendMatchedEntry(matchedEntries, fileInfo, fullPath, fileType)
-				}
-			}
-		}
-	}
-}
-
-func getFilesBySearch(c *gin.Context) {
-	s := middleware.ExtractServer(c)
-	dir := strings.TrimSuffix(c.Query("directory"), "/")
-	pattern := c.Query("pattern")
-
-	// Convert the pattern to lowercase for case-insensitive comparison
-	patternLower := strings.ToLower(pattern)
-
-	// Check if the pattern length is at least 3 characters
-	if len(pattern) < 3 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Pattern must be at least 3 characters long"})
-		return
-	}
-
-	// Prepare slices to store matched stats and directories
-	matchedEntries := []filesystem.Stat{}
-	matchedDirectories := []string{}
-
-	// Start the search from the initial directory
-	searchDirectory(s, dir, patternLower, 0, &matchedEntries, &matchedDirectories, c)
-
-	// Return the matched stats (only those that matched the pattern) and directories separately
-	if len(matchedEntries) == 0 && len(matchedDirectories) != 0 {
-		c.JSON(http.StatusOK, gin.H{"message": "No matches found."})
-	} else {
-		// For debugging purposes
-		fmt.Printf("%+q\n", matchedDirectories)
-		// Return all matched files with their stats and the name now included the directory
-		c.JSON(http.StatusOK, matchedEntries)
-	}
-}
 
 type renameFile struct {
 	To   string `json:"to"`

--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -89,6 +89,27 @@ func getServerListDirectory(c *gin.Context) {
 	}
 }
 
+func getFilesBySearch(c *gin.Context) {
+    s := ExtractServer(c)
+    dir := c.Query("directory")
+    pattern := c.Query("pattern")
+
+    // Check if the pattern length is at least 3 characters
+    if len(pattern) < 3 {
+        c.JSON(http.StatusBadRequest, gin.H{"error": "Pattern must be at least 3 characters long"})
+        return
+    }
+
+    // Proceed with directory listing if pattern is valid
+    stats, err := s.Filesystem().ListDirectory(dir)
+    if err != nil {
+        middleware.CaptureAndAbort(c, err)
+        return
+    }
+
+    c.JSON(http.StatusOK, stats)
+}
+
 type renameFile struct {
 	To   string `json:"to"`
 	From string `json:"from"`

--- a/router/router_server_files_search.go
+++ b/router/router_server_files_search.go
@@ -42,7 +42,7 @@ var blacklist = []string{"node_modules", ".wine", "appcache", "depotcache"}
 // Helper function to check if a directory name is in the blacklist
 func isBlacklisted(dirName string) bool {
 	for _, blacklisted := range blacklist {
-		if dirName == blacklisted {
+		if strings.Contains(dirName, blacklisted) {
 			return true
 		}
 	}

--- a/router/router_server_files_search.go
+++ b/router/router_server_files_search.go
@@ -1,0 +1,136 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/pelican-dev/wings/config"
+	"github.com/pelican-dev/wings/internal/ufs"
+	"github.com/pelican-dev/wings/router/middleware"
+	"github.com/pelican-dev/wings/server"
+	"github.com/pelican-dev/wings/server/filesystem"
+)
+
+// Structs needed to respond with the matched files and all their info
+type customFileInfo struct {
+	ufs.FileInfo
+	newName string
+}
+
+func (cfi customFileInfo) Name() string {
+	return cfi.newName // Return the custom name (i.e., with the directory prefix)
+}
+
+// Helper function to append matched entries
+func appendMatchedEntry(matchedEntries *[]filesystem.Stat, fileInfo ufs.FileInfo, fullPath string, fileType string) {
+	*matchedEntries = append(*matchedEntries, filesystem.Stat{
+		FileInfo: customFileInfo{
+			FileInfo: fileInfo,
+			newName:  fullPath,
+		},
+		Mimetype: fileType,
+	})
+}
+
+// todo make this config value work as now it cause a panic
+var blacklist = []string{"node_modules", ".wine", "appcache", "depotcache"}
+
+// Helper function to check if a directory name is in the blacklist
+func isBlacklisted(dirName string) bool {
+	for _, blacklisted := range blacklist {
+		if dirName == blacklisted {
+			return true
+		}
+	}
+	return false
+}
+
+// Recursive function to search through directories
+func searchDirectory(s *server.Server, dir string, patternLower string, depth int, matchedEntries *[]filesystem.Stat, matchedDirectories *[]string, c *gin.Context) {
+	if depth > config.Get().SearchRecursion.MaxRecursionDepth {
+		return // Stop recursion if depth exceeds 8
+	}
+
+	stats, err := s.Filesystem().ListDirectory(dir)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"message": "Directory not found"})
+		return
+	}
+
+	for _, fileInfo := range stats {
+		fileName := fileInfo.Name()
+		fileType := fileInfo.Mimetype
+		fileNameLower := strings.ToLower(fileName)
+		fullPath := filepath.Join(dir, fileName)
+
+		// Store directories separately
+		if fileType == "inode/directory" {
+			if isBlacklisted(fileNameLower) {
+				continue // Skip blacklisted directories
+			}
+			*matchedDirectories = append(*matchedDirectories, fullPath) // Correctly dereference to append
+
+			// Recursive search in the matched directory
+			searchDirectory(s, fullPath, patternLower, depth+1, matchedEntries, matchedDirectories, c)
+		}
+
+		// Wildcard or exact matching logic
+		if strings.ContainsAny(patternLower, "*?") {
+			if match, _ := filepath.Match(patternLower, fileNameLower); match {
+				appendMatchedEntry(matchedEntries, fileInfo, fullPath, fileType)
+			}
+		} else {
+			// Check for substring matches (case-insensitive)
+			if strings.Contains(fileNameLower, patternLower) {
+				appendMatchedEntry(matchedEntries, fileInfo, fullPath, fileType)
+			} else {
+				// Extension matching logic
+				ext := filepath.Ext(fileNameLower)
+				if strings.HasPrefix(patternLower, ".") || !strings.Contains(patternLower, ".") {
+					// Match extension without dot
+					if strings.TrimPrefix(ext, ".") == strings.TrimPrefix(patternLower, ".") {
+						appendMatchedEntry(matchedEntries, fileInfo, fullPath, fileType)
+					}
+				} else if fileNameLower == patternLower { // Full name match
+					appendMatchedEntry(matchedEntries, fileInfo, fullPath, fileType)
+				}
+			}
+		}
+	}
+}
+
+func getFilesBySearch(c *gin.Context) {
+	s := middleware.ExtractServer(c)
+	dir := strings.TrimSuffix(c.Query("directory"), "/")
+	pattern := c.Query("pattern")
+
+	// Convert the pattern to lowercase for case-insensitive comparison
+	patternLower := strings.ToLower(pattern)
+
+	// Check if the pattern length is at least 3 characters
+	if len(pattern) < 3 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Pattern must be at least 3 characters long"})
+		return
+	}
+
+	// Prepare slices to store matched stats and directories
+	matchedEntries := []filesystem.Stat{}
+	matchedDirectories := []string{}
+
+	// Start the search from the initial directory
+	searchDirectory(s, dir, patternLower, 0, &matchedEntries, &matchedDirectories, c)
+
+	// Return the matched stats (only those that matched the pattern) and directories separately
+	if len(matchedEntries) == 0 && len(matchedDirectories) != 0 {
+		c.JSON(http.StatusOK, gin.H{"message": "No matches found."})
+	} else {
+		// For debugging purposes
+		fmt.Printf("%+q\n", matchedDirectories)
+		// Return all matched files with their stats and the name now included the directory
+		c.JSON(http.StatusOK, matchedEntries)
+	}
+}

--- a/server/filesystem/filesystem.go
+++ b/server/filesystem/filesystem.go
@@ -480,9 +480,9 @@ func (fs *Filesystem) ListDirectory(p string) ([]Stat, error) {
 		case a.IsDir() && b.IsDir():
 			return 0
 		case a.IsDir():
-			return 1
-		default:
 			return -1
+		default:
+			return 1
 		}
 	})
 

--- a/server/filesystem/stat.go
+++ b/server/filesystem/stat.go
@@ -38,7 +38,7 @@ func (s *Stat) MarshalJSON() ([]byte, error) {
 		Size:      s.Size(),
 		Directory: s.IsDir(),
 		File:      !s.IsDir(),
-		Symlink:   s.Mode().Perm()&ufs.ModeSymlink != 0,
+		Symlink:   s.Mode().Type()&ufs.ModeSymlink != 0,
 		Mime:      s.Mimetype,
 	})
 }


### PR DESCRIPTION
# Changes

This PR ads an endpoint that allows you to search through files./
Closed #43 

## How it works

You give it a directory and a pattern to search, and it will return with a list of files (recursively) that matched that pattern.

Valid patterns:
- txt
- .txt
- *.txt
- start (if file for example is StartServer.bat)
- server.jar (full filename)

a pattern must be at least 3 char long

all patterns are treaded case-insensitive

![afbeelding](https://github.com/user-attachments/assets/d4f0fced-1f7f-4efa-8642-ab4766e6a3da)

What it will return:

![afbeelding](https://github.com/user-attachments/assets/216f2e84-8ee5-4468-b6e9-7c7ebaccacc4)

where name is the relative path + the filename

## Config options

- BlacklistedDirs: **currently does work because of some panic error** but for now hard-coded to:
             var blacklist = []string{"node_modules", ".wine", "appcache", "depotcache", "vendor"}
    Are the current blacklisted dir where we will not go in recursive
- MaxRecursionDepth: this works and is the max of how deep the recursion will go (default: 8)

## Performance

on a local node with a wine conan-exiles server that has almost 6 GiB of files, it takes 24ms for the request to respond (1026 files found on `***` pattern)
