### PR TITLE
Add a parameter to disable configuration file automatic creation

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -104,9 +104,10 @@ func (cp ConfigurationParser) String() string {
 // ConfigurationFile defines a configuration file for the server startup. These
 // will be looped over and modified before the server finishes booting.
 type ConfigurationFile struct {
-	FileName string                         `json:"file"`
-	Parser   ConfigurationParser            `json:"parser"`
-	Replace  []ConfigurationFileReplacement `json:"replace"`
+	FileName        string                         `json:"file"`
+	Parser          ConfigurationParser            `json:"parser"`
+	Replace         []ConfigurationFileReplacement `json:"replace"`
+	AllowCreateFile bool                           `json:"create_file"` // assumed true by unmarshal as it was the original behaviour
 
 	// Tracks Wings' configuration so that we can quickly get values
 	// out of it when variables request it.
@@ -135,6 +136,17 @@ func (f *ConfigurationFile) UnmarshalJSON(data []byte) error {
 		log.WithField("file", f.FileName).WithField("error", err).Warn("failed to unmarshal configuration file replacement")
 
 		f.Replace = []ConfigurationFileReplacement{}
+	}
+
+	// test if "create_file" exists, if not just assume true
+	if val, exists := m["create_file"]; exists && val != nil {
+		if err := json.Unmarshal(*val, &f.AllowCreateFile); err != nil {
+			log.WithField("file", f.FileName).WithField("error", err).Warn("create_file unmarshal failed assumed true")
+			f.AllowCreateFile = true
+		}
+	} else {
+		log.WithField("file", f.FileName).Info("create_file not specified assumed true")
+		f.AllowCreateFile = true
 	}
 
 	return nil

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -141,11 +141,11 @@ func (f *ConfigurationFile) UnmarshalJSON(data []byte) error {
 	// test if "create_file" exists, if not just assume true
 	if val, exists := m["create_file"]; exists && val != nil {
 		if err := json.Unmarshal(*val, &f.AllowCreateFile); err != nil {
-			log.WithField("file", f.FileName).WithField("error", err).Warn("create_file unmarshal failed assumed true")
+			log.WithField("file", f.FileName).WithField("error", err).Warn("create_file unmarshal failed")
 			f.AllowCreateFile = true
 		}
 	} else {
-		log.WithField("file", f.FileName).Info("create_file not specified assumed true")
+		log.WithField("file", f.FileName).Debug("create_file not specified assumed true")
 		f.AllowCreateFile = true
 	}
 

--- a/server/config_parser.go
+++ b/server/config_parser.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"os"
 	"runtime"
 
 	"github.com/gammazero/workerpool"
@@ -26,7 +27,9 @@ func (s *Server) UpdateConfigurationFiles() {
 			}
 			file, err := s.Filesystem().UnixFS().Touch(f.FileName, flags, 0o644)
 			if err != nil {
-				s.Log().WithField("file_name", f.FileName).WithField("error", err).WithField("create_file", f.AllowCreateFile).Error("failed to open file for configuration")
+				if !os.IsNotExist(err) || f.AllowCreateFile {
+					s.Log().WithField("file_name", f.FileName).WithField("error", err).Error("failed to open file for configuration")
+				}
 				return
 			}
 			defer file.Close()

--- a/server/config_parser.go
+++ b/server/config_parser.go
@@ -20,9 +20,13 @@ func (s *Server) UpdateConfigurationFiles() {
 		f := cf
 
 		pool.Submit(func() {
-			file, err := s.Filesystem().UnixFS().Touch(f.FileName, ufs.O_RDWR|ufs.O_CREATE, 0o644)
+			flags := ufs.O_RDWR
+			if f.AllowCreateFile {
+				flags |= ufs.O_CREATE
+			}
+			file, err := s.Filesystem().UnixFS().Touch(f.FileName, flags, 0o644)
 			if err != nil {
-				s.Log().WithField("file_name", f.FileName).WithField("error", err).Error("failed to open file for configuration")
+				s.Log().WithField("file_name", f.FileName).WithField("error", err).WithField("create_file", f.AllowCreateFile).Error("failed to open file for configuration")
 				return
 			}
 			defer file.Close()


### PR DESCRIPTION
# Changes
* This should add the possibility to disable automatic creation of the configuration files by the daemon
* Closes https://github.com/pelican-dev/panel/discussions/608#discussion-7275965 (as explained in the discussion, adding a flag instead of glob support might be better)

# Why
In very specific cases, configuration files should not be created by the daemon before the server first startup as they have not been created during the installation process.
This new flag enables egg creators to specify (default true) if the file should be created or not when the daemon tries to parse it.

# What it add
![{Server File Config}](https://github.com/user-attachments/assets/cb8eead0-9b57-45cd-8f56-bfa808a7e944)
(This is just an example on the Vanilla Minecraft egg, this is not where I think the flag would be useful)

# How
When the daemon tries to open the file to parse it, changing the function to Open instead of Touch makes it return an error instead of creating the file. If the error is "IsNotExist" and "create_file" is false just return without logging an error.

Config parser file open function edition :
![{AC38805D-4F4F-41D7-9B60-2084BE086CC4}](https://github.com/user-attachments/assets/7077ecd1-7ef3-447e-8959-4a2a854be452)
Add the flag to the ConfigurationFile struct :
![{E02BC110-3581-4054-A64D-61F0EECFCCDB}](https://github.com/user-attachments/assets/c7256333-700c-452d-bd22-c9be960de3f4)
UnmarshalJSON function addition :
![{67C5CD79-627D-4A2E-A03E-2724037B8D74}](https://github.com/user-attachments/assets/e23a4107-3f63-4d20-a884-fefde6fed85f)