### PR TITLE
Fix Auto Deploy remote

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -156,8 +156,6 @@ func configureCmdRun(cmd *cobra.Command, args []string) {
 	}
 	
 	// Manually specify the Panel URL as it won't be decoded from JSON.
-	// @see https://github.com/pterodactyl/panel/issues/5087
-	// @see https://github.com/pterodactyl/wings/security/advisories/GHSA-gqmf-jqgv-v8fw
 	cfg.PanelLocation = configureArgs.PanelURL
 
 	if err = config.WriteToDisk(cfg); err != nil {

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -154,6 +154,11 @@ func configureCmdRun(cmd *cobra.Command, args []string) {
 	if err := json.Unmarshal(b, cfg); err != nil {
 		panic(err)
 	}
+	
+	// Manually specify the Panel URL as it won't be decoded from JSON.
+	// @see https://github.com/pterodactyl/panel/issues/5087
+	// @see https://github.com/pterodactyl/wings/security/advisories/GHSA-gqmf-jqgv-v8fw
+	cfg.PanelLocation = configureArgs.PanelURL
 
 	if err = config.WriteToDisk(cfg); err != nil {
 		panic(err)


### PR DESCRIPTION
`remote` won't be parsed from the json due to [pterodactyl/wings@5415f8a](https://github.com/pterodactyl/wings/commit/5415f8ae07f533623bd8169836dd7e0b933964de#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R309)

Needed for https://github.com/pelican-dev/panel/pull/627