### PR TITLE
Stoplogic fix for default signal and shutdown console printing

### DIFF
--- a/environment/docker/power.go
+++ b/environment/docker/power.go
@@ -291,7 +291,7 @@ func (e *Environment) Terminate(ctx context.Context, signal string) error {
 	// We set it to stopping then offline to prevent crash detection from being triggered.
 	e.SetState(environment.ProcessStoppingState)
 
-	if err := e.client.ContainerKill(ctx, e.Id, container.StopOptions{Signal: signal}); err != nil && !client.IsErrNotFound(err) {
+	if err := e.client.ContainerKill(ctx, e.Id, signal); err != nil && !client.IsErrNotFound(err) {
 		return errors.WithStack(err)
 	}
 


### PR DESCRIPTION
# Changes

- Add an extra debug print that can be very usefull
- make `^C` send SIGINT and not SIGTERM 
- use ContainerKill and not ContainerStop as stop will stop printing the console output (shutdown logs for a game for example)
