### PR TITLE
Enable game server ip address allocation for macvlan driver.

### DIFF
--- a/environment/docker/container.go
+++ b/environment/docker/container.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	dockerImage "github.com/docker/docker/api/types/image" // Alias the correct images package
 
@@ -260,7 +261,25 @@ func (e *Environment) Create() error {
 		UsernsMode:  container.UsernsMode(cfg.Docker.UsernsMode),
 	}
 
-	if _, err := e.client.ContainerCreate(ctx, conf, hostConf, nil, nil, e.Id); err != nil {
+	var netConf *network.NetworkingConfig = nil //In case when no networking config is needed set nil
+	var serverNetConfig = config.Get().Docker.Network
+	if "macvlan" == serverNetConfig.Driver { //Generate networking config for macvlan driver
+		var defaultMapping = e.Config().Allocations().DefaultMapping
+		e.log().Debug("Set macvlan " + serverNetConfig.Name + " IP to " + defaultMapping.Ip)
+		netConf = &network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{
+				serverNetConfig.Name: { //Get network name from wings config
+					IPAMConfig: &network.EndpointIPAMConfig{
+						IPv4Address: defaultMapping.Ip,
+					},
+					IPAddress: defaultMapping.Ip, //Use default mapping ip address (wings support only one network per server)
+					Gateway:   serverNetConfig.Interfaces.V4.Gateway,
+				},
+			},
+		}
+	}
+	// Pass the networkings configuration or nil if none required
+	if _, err := e.client.ContainerCreate(ctx, conf, hostConf, netConf, nil, e.Id); err != nil {
 		return errors.Wrap(err, "environment/docker: failed to create container")
 	}
 

--- a/server/install.go
+++ b/server/install.go
@@ -15,6 +15,7 @@ import (
 	"github.com/apex/log"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	dockerImage "github.com/docker/docker/api/types/image" // Alias the correct images package
 
@@ -457,7 +458,25 @@ func (ip *InstallationProcess) Execute() (string, error) {
 		}
 	}()
 
-	r, err := ip.client.ContainerCreate(ctx, conf, hostConf, nil, nil, ip.Server.ID()+"_installer")
+	var netConf *network.NetworkingConfig = nil //In case when no networking config is needed set nil
+	var serverNetConfig = config.Get().Docker.Network
+	if "macvlan" == serverNetConfig.Driver { //Generate networking config for macvlan driver
+		var defaultMapping = ip.Server.Config().Allocations.DefaultMapping
+		ip.Server.Log().Debug("Set macvlan " + serverNetConfig.Name + " IP to " + defaultMapping.Ip)
+		netConf = &network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{
+				serverNetConfig.Name: { //Get network name from wings config
+					IPAMConfig: &network.EndpointIPAMConfig{
+						IPv4Address: defaultMapping.Ip,
+					},
+					IPAddress: defaultMapping.Ip, //Use default mapping ip address (wings support only one network per server)
+					Gateway:   serverNetConfig.Interfaces.V4.Gateway,
+				},
+			},
+		}
+	}
+	// Pass the networkings configuration or nil if none required
+	r, err := ip.client.ContainerCreate(ctx, conf, hostConf, netConf, nil, ip.Server.ID()+"_installer")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This is https://github.com/pterodactyl/wings/pull/203 cherrypicked onto current main branch.

> Issue:
> For macvlan driver default docker config assign first available ip. Game servers get ip assigned in order of container creation.
>
>Solution proposal:
> Wings support only one docker network for each game server. To assign correct IP default allocation could be used. Allocations > doesn't limit IPs at all, admin could set desired game server container ip and port by default allocation.

Tagging @madpeteguy for notice.