### PR TITLE
Fix file err NotExist returning 500 instead of 404

### DIFF
--- a/router/middleware/request_error.go
+++ b/router/middleware/request_error.go
@@ -118,7 +118,7 @@ func (re *RequestError) asFilesystemError() (int, string) {
 		return 0, ""
 	}
 	if filesystem.IsErrorCode(err, filesystem.ErrNotExist) ||
-		filesystem.IsErrorCode(err, filesystem.ErrCodePathResolution) ||
+		filesystem.IsErrorCode(err, filesystem.ErrCodePathResolution) || strings.Contains(err.Error(), "file does not exist") ||
 		strings.Contains(err.Error(), "resolves to a location outside the server root") {
 		return http.StatusNotFound, "The requested resources was not found on the system."
 	}

--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -37,7 +37,13 @@ func getServerFileContents(c *gin.Context) {
 	}
 	f, st, err := s.Filesystem().File(p)
 	if err != nil {
-		middleware.CaptureAndAbort(c, err)
+		if strings.Contains(err.Error(), "file does not exist") {
+			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
+				"error":      "The requested resources was not found on the system.",
+				"request_id": c.Writer.Header().Get("X-Request-Id")})
+		} else {
+			middleware.CaptureAndAbort(c, err)
+		}
 		return
 	}
 	defer f.Close()
@@ -88,7 +94,6 @@ func getServerListDirectory(c *gin.Context) {
 		c.JSON(http.StatusOK, stats)
 	}
 }
-
 
 type renameFile struct {
 	To   string `json:"to"`


### PR DESCRIPTION
# Changes

Makes the middleware not error out if a file does not exist and make wings return 404 as for some reason the asFilesystemError function code seems to be ignored

# Closes
#48 