### PR TITLE
Ensure Accurate Container Stop State with Signal Validation

### DIFF
--- a/environment/docker/power.go
+++ b/environment/docker/power.go
@@ -337,7 +337,7 @@ func (e *Environment) Terminate(ctx context.Context, signal string) error {
 			}
 			e.log().WithFields(log.Fields{
 				"id": e.Id,
-			}).Debug("Sent SIGKILL to container because it did not stop by itself in time")
+			}).Debug("Sent SIGKILL to container: graceful shutdown timed out")
 			
 			// Update state to offline after SIGKILL.
 			e.SetState(environment.ProcessOfflineState)


### PR DESCRIPTION
# Description

Enhance container stop logic to handle non-responsive containers more reliably.

# Explanation

Previously, we relied on `ContainerKill` to stop a Docker container with the signal provided. If the operation returned without an error, we assumed the container had stopped. However, according to the [Docker Kill Documentation](https://docs.docker.com/reference/cli/docker/container/kill/#description), if the provided signal is not appropriate for the application, the container may continue running while our system incorrectly assumes it has stopped. This leads to errors on the next start attempt because the container is still active.

Initially, we attempted to use `ContainerStop`, which sends the signal and escalates to `SIGKILL` if the container does not stop within a specified timeout. However, this approach had a significant drawback: within one second of initiating `ContainerStop`, the Docker API stops piping console output, resulting in truncated logs even though the container is still stopping and may still be outputting data.

### New Logic

This PR introduces a more robust solution:
1. After sending the initial signal using `ContainerKill`, the container is inspected every 500ms for up to 10 seconds (matching the default timeout of `ContainerStop`).
2. If the container stops during this period, we set its state to `offline`.
3. If the container does not stop within 10 seconds, we send another `ContainerKill` with the `SIGKILL` signal to forcefully terminate it.

# Closes
Closes #55 
