### PR TITLE
Activity log crash

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -214,6 +214,9 @@ type SystemConfiguration struct {
 
 	CrashDetection CrashDetection `yaml:"crash_detection"`
 
+	// The ammount of lines the activity logs should log on server crash
+	CrashActivityLogLines int `default:"2" yaml:"crash_detection_activity_lines"`
+
 	Backups Backups `yaml:"backups"`
 
 	Transfers Transfers `yaml:"transfers"`

--- a/server/activity.go
+++ b/server/activity.go
@@ -20,6 +20,8 @@ const (
 	ActivitySftpRename          = models.Event("server:sftp.rename")
 	ActivitySftpDelete          = models.Event("server:sftp.delete")
 	ActivityFileUploaded        = models.Event("server:file.uploaded")
+	ActivityServerCrashed       = models.Event("server:crashed")
+
 )
 
 // RequestActivity is a wrapper around a LoggedEvent that is able to track additional request

--- a/server/crash.go
+++ b/server/crash.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"emperror.dev/errors"
+	"github.com/apex/log"
 
 	"github.com/pelican-dev/wings/config"
 	"github.com/pelican-dev/wings/environment"
@@ -71,12 +72,12 @@ func (s *Server) handleServerCrash() error {
 		return nil
 	}
 
-	// Get the last line from the output before the crash so we can log it
+	// Get the last lines from the output before the crash so we can log it
 	logs, err := s.Environment.Readlog(config.Get().System.CrashActivityLogLines)
 	if err != nil {
-		return errors.Wrap(err, "Faild to get the last line out of the console")
+		log.WithField("server_id", s.ID()).Warn("Faild to get the last lines out of the console for the activity logs")
 	}
-	
+
 	s.PublishConsoleOutputFromDaemon("---------- Detected server process in a crashed state! ----------")
 	s.PublishConsoleOutputFromDaemon(fmt.Sprintf("Exit code: %d", exitCode))
 	s.PublishConsoleOutputFromDaemon(fmt.Sprintf("Out of memory: %t", oomKilled))

--- a/server/crash.go
+++ b/server/crash.go
@@ -76,13 +76,6 @@ func (s *Server) handleServerCrash() error {
 	if err != nil {
 		return errors.Wrap(err, "Faild to get the last line out of the console")
 	}
-
-	// Log that the server has crashed
-	s.SaveActivity(s.NewRequestActivity("", ""), ActivityServerCrashed, models.ActivityMeta{
-		"exit_code": exitCode,
-		"oomkilled": oomKilled,
-		"logs":      logs,
-	})
 	
 	s.PublishConsoleOutputFromDaemon("---------- Detected server process in a crashed state! ----------")
 	s.PublishConsoleOutputFromDaemon(fmt.Sprintf("Exit code: %d", exitCode))
@@ -100,6 +93,13 @@ func (s *Server) handleServerCrash() error {
 		return &crashTooFrequent{}
 	}
 
+	// Log that the server has crashed
+	s.SaveActivity(s.NewRequestActivity("", ""), ActivityServerCrashed, models.ActivityMeta{
+		"exit_code": exitCode,
+		"oomkilled": oomKilled,
+		"logs":      logs,
+	})
+	
 	s.crasher.SetLastCrash(time.Now())
 
 	return errors.Wrap(s.HandlePowerAction(PowerActionStart), "failed to start server after crash detection")

--- a/server/crash.go
+++ b/server/crash.go
@@ -94,7 +94,7 @@ func (s *Server) handleServerCrash() error {
 	}
 
 	// Log that the server has crashed
-	s.SaveActivity(s.NewRequestActivity("", ""), ActivityServerCrashed, models.ActivityMeta{
+	s.SaveActivity(s.NewRequestActivity("", "127.0.0.1"), ActivityServerCrashed, models.ActivityMeta{
 		"exit_code": exitCode,
 		"oomkilled": oomKilled,
 		"logs":      logs,


### PR DESCRIPTION
# Changes

- Log in the activity that a server has crashed with its exit code, oomkilled, and the last 2 console lines

![afbeelding](https://github.com/user-attachments/assets/83751a1a-29b9-4678-a222-e2028e89a36f)

Note: needs a panel change for this to be visible
