### PR TITLE
Remove outdated `version` in compose file

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   wings:
     image: ghcr.io/pelican-dev/wings:latest


### PR DESCRIPTION
With docker version 25.05 the `version` in docker-compose.yml is obsolete