### PR TITLE
Fail when trying to edit a `Directory` like if it was `File` content

### DIFF
--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -41,9 +41,9 @@ func getServerFileContents(c *gin.Context) {
 			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
 				"error":      "The requested resources was not found on the system.",
 				"request_id": c.Writer.Header().Get("X-Request-Id")})
-		} else if strings.Contains(err.Error(), "is a directory") {
+		} else if strings.Contains(err.Error(), "filesystem: is a directory") {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
-				"error":      "The requested resource is a directory, not a file.",
+				"error":      "Cannot perform that action: file is a directory.",
 				"request_id": c.Writer.Header().Get("X-Request-Id"),
 			})
 		} else {

--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -41,6 +41,11 @@ func getServerFileContents(c *gin.Context) {
 			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
 				"error":      "The requested resources was not found on the system.",
 				"request_id": c.Writer.Header().Get("X-Request-Id")})
+		} else if strings.Contains(err.Error(), "is a directory") {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+				"error":      "The requested resource is a directory, not a file.",
+				"request_id": c.Writer.Header().Get("X-Request-Id"),
+			})
 		} else {
 			middleware.CaptureAndAbort(c, err)
 		}

--- a/server/filesystem/filesystem.go
+++ b/server/filesystem/filesystem.go
@@ -83,7 +83,7 @@ func (fs *Filesystem) File(p string) (ufs.File, Stat, error) {
 		return nil, Stat{}, err
 	}
 	if st.IsDir() {
-		return f, Stat{}, errors.New("is a directory")
+		return f, Stat{}, errors.New("filesystem: is a directory")
 	}
 	return f, st, nil
 }

--- a/server/filesystem/filesystem.go
+++ b/server/filesystem/filesystem.go
@@ -82,6 +82,9 @@ func (fs *Filesystem) File(p string) (ufs.File, Stat, error) {
 		_ = f.Close()
 		return nil, Stat{}, err
 	}
+	if st.IsDir() {
+		return f, Stat{}, errors.New("is a directory")
+	}
 	return f, st, nil
 }
 


### PR DESCRIPTION
Catch and inform the panel about
![image](https://github.com/user-attachments/assets/418d295f-7db5-4b40-92fe-42ae73ea132b)
https://github.com/pelican-dev/panel/pull/1135