### PR TITLE
Use `findCopySuffix`

### DIFF
--- a/server/filesystem/compress.go
+++ b/server/filesystem/compress.go
@@ -41,31 +41,38 @@ func (fs *Filesystem) CompressFiles(dir string, name string, paths []string) (uf
 		return nil, fmt.Errorf("no valid files to compress")
 	}
 
+	dirfd, _, closeFd, err := fs.unixFS.SafePath(dir)
+	defer closeFd()
+	if err != nil {
+		return nil, err
+	}
+
 	a := &Archive{Filesystem: fs, BaseDirectory: dir, Files: validPaths}
-	d := path.Join(
-		dir,
-		fmt.Sprintf("%s.%s",
-			func() string {
-				if name != "" {
-					return name
-				}
-				return fmt.Sprintf("archive-%s", strings.ReplaceAll(time.Now().Format(time.RFC3339), ":", ""))
-			}(),
-			".tar.gz",
-		))
-	f, err := fs.unixFS.OpenFile(d, ufs.O_WRONLY|ufs.O_CREATE, 0o644)
+	if name == "" {
+		name = fmt.Sprintf("archive-%s.tar.gz", strings.ReplaceAll(time.Now().Format(time.RFC3339), ":", ""))
+	} else {
+		name, err = fs.findCopySuffix(dirfd, name, ".tar.gz")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	f, err := fs.unixFS.OpenFileat(dirfd, name, ufs.O_WRONLY|ufs.O_CREATE, 0o644)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
+
 	cw := ufs.NewCountedWriter(f)
 	if err := a.Stream(context.Background(), cw); err != nil {
 		return nil, err
 	}
+
 	if !fs.unixFS.CanFit(cw.BytesWritten()) {
-		_ = fs.unixFS.Remove(d)
+		_ = fs.unixFS.Remove(path.Join(dir, name))
 		return nil, newFilesystemError(ErrCodeDiskSpace, nil)
 	}
+
 	fs.unixFS.Add(cw.BytesWritten())
 	return f.Stat()
 }

--- a/server/filesystem/filesystem.go
+++ b/server/filesystem/filesystem.go
@@ -275,11 +275,15 @@ func (fs *Filesystem) Chmod(path string, mode ufs.FileMode) error {
 // looping endlessly.
 func (fs *Filesystem) findCopySuffix(dirfd int, name, extension string) (string, error) {
 	var i int
-	suffix := " copy"
+	suffix := ""
 
 	for i = 0; i < 51; i++ {
-		if i > 0 {
-			suffix = " copy " + strconv.Itoa(i)
+		if i == 1 {
+			suffix = " copy"
+		} else if i == 50 {
+			suffix = " copy." + time.Now().Format(time.RFC3339)
+		} else if i > 1 {
+			suffix = " copy " + strconv.Itoa(i-1)
 		}
 
 		n := name + suffix + extension
@@ -290,10 +294,6 @@ func (fs *Filesystem) findCopySuffix(dirfd int, name, extension string) (string,
 				return "", err
 			}
 			break
-		}
-
-		if i == 50 {
-			suffix = "copy." + time.Now().Format(time.RFC3339)
 		}
 	}
 


### PR DESCRIPTION
https://github.com/pelican-dev/wings/pull/83 got merged too soon, if you create an archive with a name that already exists it overwrites it instead of appending `copy` to its name
> I know `findCopySuffix` is also used in `copyFile` but i didn't feel like checking the same thing that's already in the loop so i though might as well adapt it to not add suffix if the file doesn't already exist.