### PR TITLE
Fix archives always created at Root & getting overwritten

### DIFF
--- a/server/filesystem/compress.go
+++ b/server/filesystem/compress.go
@@ -42,24 +42,23 @@ func (fs *Filesystem) CompressFiles(dir string, name string, paths []string) (uf
 	}
 
 	d := path.Join(dir, name)
+	extension := ".tar.gz"
 	a := &Archive{Filesystem: fs, BaseDirectory: dir, Files: validPaths}
 	if name == "" {
-		name = fmt.Sprintf("archive-%s.tar.gz", strings.ReplaceAll(time.Now().Format(time.RFC3339), ":", ""))
-		d = path.Join(dir, name)
+		name = fmt.Sprintf("archive-%s%s", strings.ReplaceAll(time.Now().Format(time.RFC3339), ":", ""), extension)
 	} else {
-		dirfd, _, closeFd, err := fs.unixFS.SafePath(d)
+		dirfd, _, closeFd, err := fs.unixFS.SafePath(d + extension)
 		defer closeFd()
 		if err != nil {
 			return nil, err
 		}
-
-		extension := fs.Ext(name)
 
 		name, err = fs.findCopySuffix(dirfd, name, extension)
 		if err != nil {
 			return nil, err
 		}
 	}
+	d = path.Join(dir, name)
 
 	f, err := fs.unixFS.OpenFile(d, ufs.O_WRONLY|ufs.O_CREATE, 0o644)
 	if err != nil {

--- a/server/filesystem/filesystem.go
+++ b/server/filesystem/filesystem.go
@@ -329,8 +329,9 @@ func (fs *Filesystem) Copy(p string) error {
 		return err
 	}
 
-	baseName := info.Name()
-	extension := fs.Ext(baseName)
+	base := info.Name()
+	extension := fs.Ext(base)
+	baseName := strings.TrimSuffix(base, extension)
 
 	newName, err := fs.findCopySuffix(dirfd, baseName, extension)
 	if err != nil {


### PR DESCRIPTION
When you created an archive, named or no it was always put in / regardless of the current path.
named archive would get overwritten even if they already exist since the `findCopySuffix` fd was wrong.
Add `fs.Ext` helper to retrieve file extension even for 2 dots ones (.tar.gz)
https://github.com/pelican-dev/panel/issues/1275