### PR TITLE
Implement `Sftp` keyOnly authentication

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,8 @@ type SftpConfiguration struct {
 	Port int `default:"2022" json:"bind_port" yaml:"bind_port"`
 	// If set to true, no write actions will be allowed on the SFTP server.
 	ReadOnly bool `default:"false" yaml:"read_only"`
+	// If set to true users won't be able to login using their password.
+	KeyOnly bool `default:"false" yaml:"key_only"`
 }
 
 // ApiConfiguration defines the configuration for the internal API that is

--- a/remote/errors.go
+++ b/remote/errors.go
@@ -62,3 +62,9 @@ type SftpInvalidCredentialsError struct{}
 func (ice SftpInvalidCredentialsError) Error() string {
 	return "the credentials provided were invalid"
 }
+
+type SftpKeyOnlyError struct{}
+
+func (ice SftpKeyOnlyError) Error() string {
+	return "password authentication is disabled; only SSH keys are allowed"
+}

--- a/sftp/server.go
+++ b/sftp/server.go
@@ -223,6 +223,11 @@ func (c *SFTPServer) makeCredentialsRequest(conn ssh.ConnMetadata, t remote.Sftp
 		return nil, &remote.SftpInvalidCredentialsError{}
 	}
 
+	if t == remote.SftpAuthPassword && config.Get().System.Sftp.KeyOnly {
+		logger.Warn("failed to validate user credentials (password authentication is disabled; only SSH keys are allowed)")
+		return nil, &remote.SftpKeyOnlyError{}
+	}
+
 	resp, err := c.manager.Client().ValidateSftpCredentials(context.Background(), request)
 	if err != nil {
 		if _, ok := err.(*remote.SftpInvalidCredentialsError); ok {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ba86c5d3-b0b4-4ef5-bd92-69ed2dbf2b0b)
I have no idea how to let the user know that password auth is disabled within the SFTP client.