### PR TITLE
Fix unidiomatic error handling, unchecked errors, and other unidiomatic code

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"crypto/tls"
 	"fmt"
+	"github.com/pelican-dev/wings/utils"
 	"io"
 	"log"
 	"net/http"
@@ -134,7 +135,7 @@ func configureCmdRun(cmd *cobra.Command, args []string) {
 		fmt.Println("Failed to fetch configuration from the panel.\n", err.Error())
 		os.Exit(1)
 	}
-	defer res.Body.Close()
+	defer utils.CloseResponseBodyWithErrorHandling(res.Body)
 
 	if res.StatusCode == http.StatusForbidden || res.StatusCode == http.StatusUnauthorized {
 		fmt.Println("The authentication credentials provided were not valid.")

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -110,7 +110,10 @@ func configureCmdRun(cmd *cobra.Command, args []string) {
 		})
 	}
 
-	if err := survey.Ask(questions, &configureArgs); err != nil && err != terminal.InterruptErr {
+	if err := survey.Ask(questions, &configureArgs); err != nil {
+		if err == terminal.InterruptErr {
+			return
+		}
 		log.Fatal(err)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -666,7 +666,12 @@ func EnableLogRotation() error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func(f *os.File) {
+		err := f.Close()
+		if err != nil {
+			log.WithError(err).Error("failed to close logrotate file")
+		}
+	}(f)
 
 	t, err := template.New("logrotate").Parse(`{{.LogDirectory}}/wings.log {
     size 10M

--- a/environment/docker/container.go
+++ b/environment/docker/container.go
@@ -336,7 +336,12 @@ func (e *Environment) Readlog(lines int) ([]string, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	defer r.Close()
+	defer func(r io.ReadCloser) {
+		err := r.Close()
+		if err != nil {
+			log.WithError(err).Error("failed to close container logs reader")
+		}
+	}(r)
 
 	var out []string
 	scanner := bufio.NewScanner(r)
@@ -423,7 +428,12 @@ func (e *Environment) ensureImageExists(image string) error {
 
 		return errors.Wrapf(err, "environment/docker: failed to pull \"%s\" image for server", image)
 	}
-	defer out.Close()
+	defer func(out io.ReadCloser) {
+		err := out.Close()
+		if err != nil {
+			log.WithError(err).Error("failed to close image pull reader")
+		}
+	}(out)
 
 	log.WithField("image", image).Debug("pulling docker image... this could take a bit of time")
 

--- a/environment/docker/stats.go
+++ b/environment/docker/stats.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"github.com/apex/log"
 	"io"
 	"math"
 	"time"
@@ -44,7 +45,12 @@ func (e *Environment) pollResources(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer stats.Body.Close()
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			log.WithError(err).Error("failed to close Docker container stats body")
+		}
+	}(stats.Body)
 
 	uptime, err := e.Uptime(ctx)
 	if err != nil {

--- a/internal/ufs/removeall_unix.go
+++ b/internal/ufs/removeall_unix.go
@@ -12,6 +12,7 @@ package ufs
 
 import (
 	"errors"
+	"github.com/apex/log"
 	"io"
 	"os"
 
@@ -59,7 +60,12 @@ func removeAll(fs unixFS, path string) error {
 		// If parent does not exist, base cannot exist. Fail silently
 		return nil
 	}
-	defer parent.Close()
+	defer func(parent File) {
+		err := parent.Close()
+		if err != nil {
+			log.WithError(err).Error("failed to close parent")
+		}
+	}(parent)
 
 	if err := removeAllFrom(fs, parent, base); err != nil {
 		if pathErr, ok := err.(*PathError); ok {
@@ -96,7 +102,12 @@ func removeContents(fs unixFS, path string) error {
 		// If parent does not exist, base cannot exist. Fail silently
 		return nil
 	}
-	defer parent.Close()
+	defer func(parent File) {
+		err := parent.Close()
+		if err != nil {
+			log.WithError(err).Error("failed to close parent")
+		}
+	}(parent)
 
 	if err := removeContentsFrom(fs, parent, base); err != nil {
 		if pathErr, ok := err.(*PathError); ok {

--- a/remote/servers.go
+++ b/remote/servers.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"context"
 	"fmt"
+	"github.com/pelican-dev/wings/utils"
 	"strconv"
 	"sync"
 
@@ -74,7 +75,7 @@ func (c *client) GetServerConfiguration(ctx context.Context, uuid string) (Serve
 	if err != nil {
 		return config, err
 	}
-	defer res.Body.Close()
+	defer utils.CloseResponseBodyWithErrorHandling(res.Body)
 
 	err = res.BindJSON(&config)
 	return config, err
@@ -85,7 +86,7 @@ func (c *client) GetInstallationScript(ctx context.Context, uuid string) (Instal
 	if err != nil {
 		return InstallationScript{}, err
 	}
-	defer res.Body.Close()
+	defer utils.CloseResponseBodyWithErrorHandling(res.Body)
 
 	var config InstallationScript
 	err = res.BindJSON(&config)
@@ -138,7 +139,7 @@ func (c *client) ValidateSftpCredentials(ctx context.Context, request SftpAuthRe
 		}
 		return auth, err
 	}
-	defer res.Body.Close()
+	defer utils.CloseResponseBodyWithErrorHandling(res.Body)
 
 	if err := res.BindJSON(&auth); err != nil {
 		return auth, err
@@ -152,7 +153,7 @@ func (c *client) GetBackupRemoteUploadURLs(ctx context.Context, backup string, s
 	if err != nil {
 		return data, err
 	}
-	defer res.Body.Close()
+	defer utils.CloseResponseBodyWithErrorHandling(res.Body)
 	if err := res.BindJSON(&data); err != nil {
 		return data, err
 	}
@@ -205,7 +206,7 @@ func (c *client) getServersPaged(ctx context.Context, page, limit int) ([]RawSer
 	if err != nil {
 		return nil, r.Meta, err
 	}
-	defer res.Body.Close()
+	defer utils.CloseResponseBodyWithErrorHandling(res.Body)
 	if err := res.BindJSON(&r); err != nil {
 		return nil, r.Meta, err
 	}

--- a/router/downloader/downloader.go
+++ b/router/downloader/downloader.go
@@ -3,6 +3,7 @@ package downloader
 import (
 	"context"
 	"fmt"
+	"github.com/pelican-dev/wings/utils"
 	"io"
 	"mime"
 	"net"
@@ -194,7 +195,7 @@ func (dl *Download) Execute() error {
 	if err != nil {
 		return ErrDownloadFailed
 	}
-	defer res.Body.Close()
+	defer utils.CloseResponseBodyWithErrorHandling(res.Body)
 	if res.StatusCode != http.StatusOK {
 		return errors.New("downloader: got bad response status from endpoint: " + res.Status)
 	}

--- a/server/backup/backup_local.go
+++ b/server/backup/backup_local.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"context"
+	"github.com/apex/log"
 	"io"
 	"os"
 	"path/filepath"
@@ -107,7 +108,12 @@ func (b *LocalBackup) Restore(ctx context.Context, _ io.Reader, callback Restore
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func(f *os.File) {
+		err := f.Close()
+		if err != nil {
+			log.WithError(err).Error("failed to close local backup file")
+		}
+	}(f)
 
 	var reader io.Reader = f
 	// Steal the logic we use for making backups which will be applied when restoring

--- a/server/filesystem/filesystem_test.go
+++ b/server/filesystem/filesystem_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	. "github.com/franela/goblin"
@@ -171,7 +172,8 @@ func TestFilesystem_Writefile(t *testing.T) {
 			fs.SetDiskLimit(1024)
 
 			b := make([]byte, 1025)
-			_, err := rand.Read(b)
+			rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+			_, err := rng.Read(b)
 			g.Assert(err).IsNil()
 			g.Assert(len(b)).Equal(1025)
 

--- a/server/filesystem/filesystem_test.go
+++ b/server/filesystem/filesystem_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pelican-dev/wings/config"
 )
 
-func NewFs() (*Filesystem, *rootFs) {
+func NewFs() (*Filesystem, *RootFs) {
 	config.Set(&config.Configuration{
 		AuthenticationToken: "abc",
 		System: config.SystemConfiguration{
@@ -33,7 +33,7 @@ func NewFs() (*Filesystem, *rootFs) {
 		return nil, nil
 	}
 
-	rfs := rootFs{root: tmpDir}
+	rfs := RootFs{root: tmpDir}
 
 	p := filepath.Join(tmpDir, "server")
 	if err := os.Mkdir(p, 0o755); err != nil {
@@ -51,7 +51,7 @@ func NewFs() (*Filesystem, *rootFs) {
 	return fs, &rfs
 }
 
-type rootFs struct {
+type RootFs struct {
 	root string
 }
 
@@ -63,7 +63,7 @@ func getFileContent(file ufs.File) string {
 	return w.String()
 }
 
-func (rfs *rootFs) CreateServerFile(p string, c []byte) error {
+func (rfs *RootFs) CreateServerFile(p string, c []byte) error {
 	f, err := os.Create(filepath.Join(rfs.root, "server", p))
 
 	if err == nil {
@@ -74,11 +74,11 @@ func (rfs *rootFs) CreateServerFile(p string, c []byte) error {
 	return err
 }
 
-func (rfs *rootFs) CreateServerFileFromString(p string, c string) error {
+func (rfs *RootFs) CreateServerFileFromString(p string, c string) error {
 	return rfs.CreateServerFile(p, []byte(c))
 }
 
-func (rfs *rootFs) StatServerFile(p string) (os.FileInfo, error) {
+func (rfs *RootFs) StatServerFile(p string) (os.FileInfo, error) {
 	return os.Stat(filepath.Join(rfs.root, "server", p))
 }
 

--- a/server/filesystem/filesystem_test.go
+++ b/server/filesystem/filesystem_test.go
@@ -115,7 +115,10 @@ func TestFilesystem_Openfile(t *testing.T) {
 func TestFilesystem_Writefile(t *testing.T) {
 	g := Goblin(t)
 	fs, _ := NewFs()
-
+	closeFileWithErrorChecking := func(f ufs.File, g *G) {
+		err := f.Close()
+		g.Assert(err).IsNil()
+	}
 	g.Describe("Open and WriteFile", func() {
 		buf := &bytes.Buffer{}
 
@@ -131,7 +134,7 @@ func TestFilesystem_Writefile(t *testing.T) {
 
 			f, _, err := fs.File("test.txt")
 			g.Assert(err).IsNil()
-			defer f.Close()
+			defer closeFileWithErrorChecking(f, g)
 			g.Assert(getFileContent(f)).Equal("test file content")
 			g.Assert(fs.CachedUsage()).Equal(r.Size())
 		})
@@ -144,7 +147,7 @@ func TestFilesystem_Writefile(t *testing.T) {
 
 			f, _, err := fs.File("/some/nested/test.txt")
 			g.Assert(err).IsNil()
-			defer f.Close()
+			defer closeFileWithErrorChecking(f, g)
 			g.Assert(getFileContent(f)).Equal("test file content")
 		})
 
@@ -156,7 +159,7 @@ func TestFilesystem_Writefile(t *testing.T) {
 
 			f, _, err := fs.File("foo/bar/test.txt")
 			g.Assert(err).IsNil()
-			defer f.Close()
+			defer closeFileWithErrorChecking(f, g)
 			g.Assert(getFileContent(f)).Equal("test file content")
 		})
 
@@ -194,7 +197,7 @@ func TestFilesystem_Writefile(t *testing.T) {
 
 			f, _, err := fs.File("test.txt")
 			g.Assert(err).IsNil()
-			defer f.Close()
+			defer closeFileWithErrorChecking(f, g)
 			g.Assert(getFileContent(f)).Equal("new data")
 		})
 
@@ -558,7 +561,7 @@ func TestFilesystem_Delete(t *testing.T) {
 			err = os.Symlink(filepath.Join(rfs.root, "source.txt"), filepath.Join(rfs.root, "/server/symlink.txt"))
 			g.Assert(err).IsNil()
 
-			// Delete the symlink. (This should pass as we will delete the symlink itself, not it's target)
+			// Delete the symlink. (This should pass as we will delete the symlink itself, not its target)
 			err = fs.Delete("symlink.txt")
 			g.Assert(err).IsNil()
 

--- a/server/server.go
+++ b/server/server.go
@@ -75,9 +75,6 @@ type Server struct {
 	wsBagLocker sync.Mutex
 
 	sinks map[system.SinkName]*system.SinkPool
-
-	logSink     *system.SinkPool
-	installSink *system.SinkPool
 }
 
 // New returns a new server instance with a context and all of the default
@@ -165,7 +162,6 @@ func DetermineServerTimezone(envvars map[string]interface{}, defaultTimezone str
 	// Return the defaultTimezone if SERVER_TIMEZONE is not set, empty, or invalid
 	return defaultTimezone
 }
-
 
 // parseInvocation parses the start command in the same way we already do in the entrypoint
 // We can use this to set the container command with all variables replaced.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"github.com/apex/log"
+	"io"
+)
+
+func CloseResponseBodyWithErrorHandling(body io.ReadCloser) {
+	err := body.Close()
+	if err != nil {
+		log.WithError(err).Error("failed to close response body")
+	}
+}

--- a/wings.go
+++ b/wings.go
@@ -1,18 +1,10 @@
 package main
 
 import (
-	"math/rand"
-	"time"
-
 	"github.com/pelican-dev/wings/cmd"
 )
 
 func main() {
-	// Since we make use of the math/rand package in the code, especially for generating
-	// non-cryptographically secure random strings we need to seed the RNG. Just make use
-	// of the current time for this.
-	rand.Seed(time.Now().UnixNano())
-
 	// Execute the main binary code.
 	cmd.Execute()
 }


### PR DESCRIPTION
Check errors that are unchecked, and remove calls to panic. According to go documentation, panic should NOT be used in production. https://go.dev/doc/effective_go#panic (this same bad error handling is present in pterodactyl, and the commits where it was introduced are originally from pterodactyl, this is not pelican's fault)