### PR TITLE
Check for new `papp_` api key prefix

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -183,7 +183,7 @@ func validateField(name string, str string) error {
 			return fmt.Errorf("please provide a valid panel URL")
 		}
 	case "token":
-		if !regexp.MustCompile(`^peli_(\w{43})$`).Match([]byte(str)) && !regexp.MustCompile(`^papp_(\w{43})$`).Match([]byte(str)) {
+		if !regexp.MustCompile(`^(peli|papp)_(\w{43})$`).Match([]byte(str)) {
 			return fmt.Errorf("please provide a valid authentication token")
 		}
 	case "node":

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -183,7 +183,7 @@ func validateField(name string, str string) error {
 			return fmt.Errorf("please provide a valid panel URL")
 		}
 	case "token":
-		if !regexp.MustCompile(`^peli_(\w{43})$`).Match([]byte(str)) {
+		if !regexp.MustCompile(`^peli_(\w{43})$`).Match([]byte(str)) && !regexp.MustCompile(`^papp_(\w{43})$`).Match([]byte(str)) {
 			return fmt.Errorf("please provide a valid authentication token")
 		}
 	case "node":


### PR DESCRIPTION
See https://github.com/pelican-dev/panel/pull/1650

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token validation now accepts tokens with either peli_ or papp_ prefixes, improving compatibility with additional token formats during configuration.
  * Error messaging behavior remains unchanged when a provided token does not match accepted patterns, preserving user feedback consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->