### PR TITLE
feat: add health check endpoints

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -53,6 +53,10 @@ func Configure(m *wserver.Manager, client remote.Client) *gin.Engine {
 	// and requests are authenticated through a JWT the panel issues to the other daemon.
 	router.POST("/api/transfers", postTransfers)
 
+	// Health checks
+	router.GET("/health", getHealthCheck)
+	router.GET("/ping", getHealthCheck)
+
 	// All the routes beyond this mount will use an authorization middleware
 	// and will not be accessible without the correct Authorization header provided.
 	protected := router.Use(middleware.RequireAuthorization())

--- a/router/router_heath.go
+++ b/router/router_heath.go
@@ -1,0 +1,12 @@
+package router
+
+import (
+	"net/http"
+	"github.com/gin-gonic/gin"
+)
+
+func getHealthCheck(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"status": "ok",
+	})
+}


### PR DESCRIPTION
- Adds /health and /ping REST endpoints
- Useful for monitoring

I've not checked if people have wanted this or asked but it seems like people should? Not sure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added two public health-check endpoints: GET /health and GET /ping. Both return a 200 OK with a simple status payload, enabling easy uptime monitoring and load balancer checks.
  - Endpoints are accessible without authentication and do not affect existing routing or middleware behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->