### PR TITLE
Reorder config loading to load config and *then* fill in missing defaults

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -367,12 +367,6 @@ type SearchRecursion struct {
 // This function does not modify the currently stored global configuration.
 func NewAtPath(path string) (*Configuration, error) {
 	var c Configuration
-	// Configures the default values for many of the configuration options present
-	// in the structs. Values set in the configuration file take priority over the
-	// default values.
-	if err := defaults.Set(&c); err != nil {
-		return nil, err
-	}
 	// Track the location where we created this configuration.
 	c.path = path
 	return &c, nil
@@ -551,6 +545,13 @@ func FromFile(path string) error {
 
 	if err := yaml.Unmarshal(b, c); err != nil {
 		return err
+	}
+
+	// Configures the default values for many of the configuration options present
+	// in the structs. Values set in the configuration file will not be overridden by the
+	// default values.
+	if err := defaults.Set(&c); err != nil {
+		return nil, err
 	}
 
 	c.Token = Token{

--- a/config/config.go
+++ b/config/config.go
@@ -550,8 +550,8 @@ func FromFile(path string) error {
 	// Configures the default values for many of the configuration options present
 	// in the structs. Values set in the configuration file will not be overridden by the
 	// default values.
-	if err := defaults.Set(&c); err != nil {
-		return nil, err
+	if err := defaults.Set(c); err != nil {
+		return err
 	}
 
 	c.Token = Token{


### PR DESCRIPTION
Quoting the [original PR](https://github.com/pterodactyl/wings/pull/185):

> This PR changes the order of operations when loading the config.yml
> 
> Currently when wings starts up, it starts with an empty Configuration struct that is then filled with the defaults and THEN we overlay the data from the config.yml using yaml.Unmarshal(). This overwrites any values in the struct with any values that exist in the config.yml
> 
> The issue is when encountering an array/list/map yaml.Unmarshal() will merge the values from the config.yml with the defaults. Such as shown in https://github.com/pterodactyl/panel/issues/5008
> 
> By changing the order so that defaults.Set() is called after the struct has been filled with the data from config.yml, only missing keys will be filled
> 
> This would resolve https://github.com/pterodactyl/panel/issues/5008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default configuration values are now applied when loading from a file, ensuring consistent behavior for file-based configurations.
  * Newly created configurations no longer auto-populate defaults at creation; defaults are applied when a config is loaded from disk, which may affect workflows relying on immediate defaults.

* **Documentation**
  * Clarified when configuration defaults are applied to align expectations for file-loaded vs. newly created configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->