### PR TITLE
Fix path handling in file compression logic

### DIFF
--- a/server/filesystem/compress.go
+++ b/server/filesystem/compress.go
@@ -70,9 +70,14 @@ func (fs *Filesystem) CompressFiles(dir string, name string, paths []string, ext
 		name = fmt.Sprintf("archive-%s%s", strings.ReplaceAll(time.Now().Format(time.RFC3339), ":", ""), ext)
 	} else {
 		dirfd, _, closeFd, err := fs.unixFS.SafePath(path.Join(dir, name) + ext)
-		defer closeFd()
 		if err != nil {
+			if closeFd != nil {
+				closeFd()
+			}
 			return nil, "", err
+		}
+		if closeFd != nil {
+			defer closeFd()
 		}
 
 		name, err = fs.findCopySuffix(dirfd, name, ext)


### PR DESCRIPTION
# Changes

- This fixes an issue where if you are creating an archive in a sub dir that wings would error because I forgot to tell it that the base we need to do base path + dir on disk as if you are in a folder it would look for the file in the root and not in the folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compressed archives now correctly include directory paths for archived files.
  * Improved resource handling to ensure file descriptors are properly closed on errors, reducing leaks and upload failures.
  * Consistent handling of file entries in archives to prevent missing files or incorrect paths during compression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->