### PR TITLE
feat(files): add recursive denylist checks when deleting directories

### DIFF
--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -237,12 +237,10 @@ func postServerDeleteFiles(c *gin.Context) {
 			case <-ctx.Done():
 				return ctx.Err()
 			default:
-				if err := s.Filesystem().IsIgnored(pi); err != nil {
-					return err
-				}
-				return s.Filesystem().Delete(pi)
+				return s.Filesystem().SafeDeleteRecursively(pi)
 			}
 		})
+		
 	}
 
 	if err := g.Wait(); err != nil {


### PR DESCRIPTION
# Changes

- Previously, when removing a whole directory, the Wings `files/delete` endpoint only checked the **top-level directory** against the denylist.  
  Subdirectories and their contents were **not validated**, allowing denylisted files inside to be deleted unintentionally.  
- This update ensures **recursive denylist checks**, so any files or subdirectories matching denylist patterns are skipped and preserved.
- Closes #138 

---

### Tested Denylist Entries
- `config.json`
- `test/dummy4`
- `test/dummy5/a.txt`
- `test/testfolder`
- `test/testfolder*`

---

### Initial Files / Folders
- `config.json`  
- `test/config.json`  
- `test/dummy4/abc`  
- `test/dummy5/a.txt`  
- `test/dummy5/b.txt`  
- `test/testfolder`  
- `test/testfolder7/a.txt`

---

### Files Remaining After Deletion
- `config.json`  
- `test/config.json`  
- `test/dummy5/abc`  
- `test/dummy5/a.txt`  
- `test/testfolder`  
- `test/testfolder7/a.txt`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file deletion behavior to respect protected/denylisted files and directories during recursive deletion operations, preventing removal of excluded content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->