### PR TITLE
Changed from fs.stat(p) to fs.unixFS.Lstat(p)

### DIFF
--- a/server/filesystem/filesystem.go
+++ b/server/filesystem/filesystem.go
@@ -406,7 +406,7 @@ func (fs *Filesystem) Delete(p string) error {
 // it recursively deletes all non-denylisted files and subdirectories. Empty directories
 // are removed automatically, but directories containing denylisted files are preserved.
 func (fs *Filesystem) SafeDeleteRecursively(p string) error {
-	info, err := fs.Stat(p)
+	info, err := fs.unixFS.Lstat(p)
 	if err != nil {
 		return err
 	}
@@ -436,7 +436,7 @@ func (fs *Filesystem) SafeDeleteRecursively(p string) error {
 				return err
 			}
 			// Check if the directory still exists after recursive deletion
-			if _, statErr := fs.Stat(child); statErr == nil {
+			if _, statErr := fs.unixFS.Lstat(child); statErr == nil {
 				hasRemainingFiles = true
 			}
 			continue


### PR DESCRIPTION
SafeDeleteRecursively was failing with "openat2: bad path resolution" errors when encountering symlinks that point outside the filesystem root.

Changes :

* Replaced calls to `fs.Stat` with `fs.unixFS.Lstat` in both the initial file info retrieval and the directory existence check, which allows for correct processing of symbolic links and special files during recursive deletion. 

I have tested this and it fixes the issue and doesnt seem to cause any side effects

This fixes the path resolution errors while maintaining the security boundaries that openat2 enforces.
Let me know if you see any issues with this!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of symlinks during recursive deletion operations for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->