### PR TITLE
Option to assume server transfer is already done in cluster

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -278,6 +278,12 @@ type Transfers struct {
 	//
 	// Defaults to 0 (unlimited)
 	DownloadLimit int `default:"0" yaml:"download_limit"`
+
+	// StoragePool acts as a per-node identifier to signal that this node shares a common data volume
+	// with other nodes in the cluster. When this value is set and matches the value on a target node,
+	// Wings will assume the server data already exists on the target and will skip copying and cleanup.
+	// When empty, transfers behave normally.
+	StoragePool string `yaml:"storage_pool"`
 }
 
 type ConsoleThrottles struct {


### PR DESCRIPTION
Hi, I'm building a Ceph based infrastructure that syncs the volume (ex: /var/lib/pelican/volumes) across nodes in cluster. A roadblock is that wings cares about transfer and cleaning up, the stack will not work as expected.

A configuration option is added for the purpose to circumvent this behavior. When configured:

```yaml
system:
  transfers:
    storage_pool: something123
```

Wings will not attempt to transfer files or cleanup.

It will still move server to `storage_pool` that is not match, but the cleanup will not work at the moment.

At the moment, it works with the stack if simply configured with a common name across nodes with the following setup:
- Replicated NFS/CephFS
- S3 Backup (file backup is expected for transfers)

If the configuration left empty, wings will behave as just normal.