### PR TITLE
Option to omit transfer on same storage volume

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -278,6 +278,12 @@ type Transfers struct {
 	//
 	// Defaults to 0 (unlimited)
 	DownloadLimit int `default:"0" yaml:"download_limit"`
+
+	// StoragePool acts as a per-node identifier to signal that this node shares a common data volume
+	// with other nodes in the cluster. When this value is set and matches the value on a target node,
+	// Wings will assume the server data already exists on the target and will skip copying and cleanup.
+	// When empty, transfers behave normally.
+	StoragePool string `yaml:"storage_pool"`
 }
 
 type ConsoleThrottles struct {

--- a/config/config.go
+++ b/config/config.go
@@ -279,11 +279,16 @@ type Transfers struct {
 	// Defaults to 0 (unlimited)
 	DownloadLimit int `default:"0" yaml:"download_limit"`
 
-	// StoragePool acts as a per-node identifier to signal that this node shares a common data volume
-	// with other nodes in the cluster. When this value is set and matches the value on a target node,
-	// Wings will assume the server data already exists on the target and will skip copying and cleanup.
-	// When empty, transfers behave normally.
-	StoragePool string `yaml:"storage_pool"`
+	// StoragePool configures whether this node participates in a shared storage pool.
+	StoragePool StoragePoolConfiguration `yaml:"storage_pool"`
+}
+
+type StoragePoolConfiguration struct {
+	// Enabled signals that this node shares a common data volume with other nodes.
+	Enabled bool `default:"false" yaml:"enabled"`
+
+	// PoolName is a per-node identifier used to compare shared storage pool membership across nodes.
+	PoolName string `yaml:"pool_name"`
 }
 
 type ConsoleThrottles struct {

--- a/router/router_server.go
+++ b/router/router_server.go
@@ -275,8 +275,16 @@ func deleteServer(c *gin.Context) {
 	//
 	// In addition, servers with large amounts of files can take some time to finish deleting,
 	// so we don't want to block the HTTP call while waiting on this.
-	// Skip file removal when a storage pool is enabled, since the data is shared across nodes.
-	if !config.Get().System.Transfers.StoragePool.Enabled {
+	//
+	// Only skip file removal when:
+	//   1. shared storage pooling is explicitly enabled,
+	//   2. the pool has a name configured, and
+	//   3. this server is actively being transferred.
+	//
+	// This avoids preserving data for ordinary server deletions.
+	pool := config.Get().System.Transfers.StoragePool
+	skipFileRemoval := pool.Enabled && pool.PoolName != "" && s.IsTransferring()
+	if !skipFileRemoval {
 		go func(s *server.Server) {
 			fs := s.Filesystem()
 			p := fs.Path()

--- a/router/router_server.go
+++ b/router/router_server.go
@@ -275,8 +275,8 @@ func deleteServer(c *gin.Context) {
 	//
 	// In addition, servers with large amounts of files can take some time to finish deleting,
 	// so we don't want to block the HTTP call while waiting on this.
-	// Skip file removal when a storage pool is configured, since the data is shared across nodes.
-	if config.Get().System.Transfers.StoragePool == "" {
+	// Skip file removal when a storage pool is enabled, since the data is shared across nodes.
+	if !config.Get().System.Transfers.StoragePool.Enabled {
 		go func(s *server.Server) {
 			fs := s.Filesystem()
 			p := fs.Path()

--- a/router/router_transfer.go
+++ b/router/router_transfer.go
@@ -132,7 +132,7 @@ func postTransfers(c *gin.Context) {
 	{
 		remotePool := config.Get().System.Transfers.StoragePool
 		sourcePool := c.GetHeader("X-Storage-Pool")
-		if remotePool != "" && sourcePool != "" && strings.EqualFold(remotePool, sourcePool) {
+		if remotePool.Enabled && remotePool.PoolName != "" && sourcePool != "" && strings.EqualFold(remotePool.PoolName, sourcePool) {
 			if err := trnsfr.Server.CreateEnvironment(); err != nil {
 				middleware.CaptureAndAbort(c, err)
 				return

--- a/server/transfer/source.go
+++ b/server/transfer/source.go
@@ -61,8 +61,8 @@ func (t *Transfer) PushArchiveToTarget(url, token string) ([]byte, error) {
 		return nil, err
 	}
 	req.Header.Set("Authorization", token)
-	if sp != "" {
-		req.Header.Set("X-Storage-Pool", sp)
+	if sp.Enabled && sp.PoolName != "" {
+		req.Header.Set("X-Storage-Pool", sp.PoolName)
 	}
 
 	// Create a new multipart writer that writes the archive to the pipe.


### PR DESCRIPTION
Hi, I'm building a Ceph based infrastructure that syncs the volume (ex: /var/lib/pelican/volumes) across nodes in cluster. A roadblock is that wings cares about transfer and cleaning up, the stack will not work as expected.

A configuration option is added for the purpose to circumvent this behavior. When configured:

```yaml
system:
  transfers:
    storage_pool:
      enabled: false
      pool_name: something123
```

Wings will not attempt to transfer files or cleanup.

It will still move server to `storage_pool` that is not match, but the cleanup will not work at the moment.

At the moment, it works with the stack if simply configured with a common name across nodes with the following setup:
- Replicated NFS/CephFS
- S3 Backup (file backup is expected for transfers)

If the configuration left empty, wings will behave as just normal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added storage pool configuration to enable shared storage per node with configurable pool names.
  * Transfers can short-circuit when storage pool settings match, speeding up successful transfers.

* **Bug Fixes / Behavior Changes**
  * Server cleanup now preserves files during active transfers when storage pool is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->