### PR TITLE
feat(docker): add support for container network mode

### DIFF
--- a/config/config_docker.go
+++ b/config/config_docker.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/base64"
 	"sort"
+	"strings"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/registry"
@@ -40,6 +41,15 @@ type DockerNetworkConfiguration struct {
 	EnableICC  bool                    `default:"true" yaml:"enable_icc"`
 	NetworkMTU int64                   `default:"1500" yaml:"network_mtu"`
 	Interfaces dockerNetworkInterfaces `yaml:"interfaces"`
+}
+
+// IsContainerNetworkMode returns true if the network mode shares another container's network namespace.
+// When using "container:<name>" mode, the container inherits the target container's network stack,
+// including hostname, DNS, and network interfaces.
+func (c DockerNetworkConfiguration) IsContainerNetworkMode() bool {
+	// Must have "container:" prefix and at least one character for the container name.
+	// Docker rejects "container:" without a name with "invalid container format container:".
+	return strings.HasPrefix(c.Mode, "container:") && len(c.Mode) > len("container:")
 }
 
 // DockerConfiguration defines the docker configuration used by the daemon when

--- a/config/config_docker_test.go
+++ b/config/config_docker_test.go
@@ -1,0 +1,32 @@
+package config
+
+import "testing"
+
+// TestDockerNetworkConfiguration_IsContainerNetworkMode tests the IsContainerNetworkMode
+// method to ensure it correctly identifies when the network mode is set to share another
+// container's network namespace (i.e., "container:<name>" format).
+func TestDockerNetworkConfiguration_IsContainerNetworkMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     string
+		expected bool
+	}{
+		{"container mode with name", "container:caddy", true},
+		{"container mode with different name", "container:some-vpn-container", true},
+		{"container mode empty name", "container:", false}, // Docker rejects "container:" without a name
+		{"default pelican network", "pelican_nw", false},
+		{"bridge network", "bridge", false},
+		{"host network", "host", false},
+		{"empty string", "", false},
+		{"partial match", "containers", false}, // Should not match without colon
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := DockerNetworkConfiguration{Mode: tt.mode}
+			if got := c.IsContainerNetworkMode(); got != tt.expected {
+				t.Errorf("IsContainerNetworkMode() = %v, want %v for mode %q", got, tt.expected, tt.mode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add proper support for `network_mode: container:<name>` which allows containers to share another container's network namespace.

## Problem

When using container network mode, Docker requires that hostname, domainname, DNS, and port bindings are inherited from the target container. Wings previously set these unconditionally, causing container creation to fail with: `conflicting options: hostname and the network mode`.

## Changes

- Add `IsContainerNetworkMode()` helper method to `DockerNetworkConfiguration`
- Skip hostname/domainname configuration when using container network mode
- Skip DNS configuration when using container network mode
- Skip port exposure/bindings when using container network mode (ports must be configured on the target container)
- Add warning when `ForceOutgoingIP` is enabled with container network mode
- Apply same logic to installation containers in `server/install.go`
- Add unit tests for `IsContainerNetworkMode()`

## Use Case

- **VPN Integration**: Route traffic through a VPN container for IP protection
- **Resource Efficiency**: Reduces overhead by reusing an existing network stack instead of spawning additional network interfaces per container
- **Advanced Topologies**: Allows containers to share networking contexts for sidecar patterns, debugging, or dependency coupling (e.g., game server ↔ proxy)

Closes #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved container-network mode handling: when enabled, hostname, domain, exposed ports/port bindings, DNS, and forced outgoing IP are conditionally skipped or adjusted, with clear debug/warning messages to reflect network isolation.

* **Tests**
  * Added unit tests validating detection of container-network mode across multiple scenarios, including edge and empty-value cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->