### PR TITLE
Fix subnets and the common error: Pool overlaping

### DIFF
--- a/environment/docker.go
+++ b/environment/docker.go
@@ -73,21 +73,24 @@ func ConfigureDocker(ctx context.Context) error {
 		}
 
 		// Update the interface configuration with the actual assigned values from Docker
-		for _, ipamCfg := range resource.IPAM.Config {
-			if ipamCfg.Subnet == "" {
-				continue
-			}
-			// IPv6 subnets contain colons
-			if strings.Contains(ipamCfg.Subnet, ":") {
-				c.Docker.Network.Interfaces.V6.Subnet = ipamCfg.Subnet
-				if ipamCfg.Gateway != "" {
-					c.Docker.Network.Interfaces.V6.Gateway = ipamCfg.Gateway
+		// Skip IPAM processing for special drivers that don't have normal IPAM configs
+		if c.Docker.Network.Driver != "host" && c.Docker.Network.Driver != "overlay" && c.Docker.Network.Driver != "weavemesh" {
+			for _, ipamCfg := range resource.IPAM.Config {
+				if ipamCfg.Subnet == "" {
+					continue
 				}
-			} else {
-				c.Docker.Network.Interfaces.V4.Subnet = ipamCfg.Subnet
-				if ipamCfg.Gateway != "" {
-					c.Docker.Network.Interfaces.V4.Gateway = ipamCfg.Gateway
-					c.Docker.Network.Interface = ipamCfg.Gateway
+				// IPv6 subnets contain colons
+				if strings.Contains(ipamCfg.Subnet, ":") {
+					c.Docker.Network.Interfaces.V6.Subnet = ipamCfg.Subnet
+					if ipamCfg.Gateway != "" {
+						c.Docker.Network.Interfaces.V6.Gateway = ipamCfg.Gateway
+					}
+				} else {
+					c.Docker.Network.Interfaces.V4.Subnet = ipamCfg.Subnet
+					if ipamCfg.Gateway != "" {
+						c.Docker.Network.Interfaces.V4.Gateway = ipamCfg.Gateway
+						c.Docker.Network.Interface = ipamCfg.Gateway
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Yes, tested in FeatherWings by around 400 hosts migrating from pterodactyl wings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added retry when requested network subnets conflict or are invalid, avoiding hard failures.
  * Runtime network settings now reflect Docker-assigned subnets and gateways (IPv6 prioritized, then IPv4).

* **Refactor**
  * Network creation/resync flow updated to validate, re-inspect and log actual Docker network configuration rather than relying on a post-create fallback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->