### PR TITLE
Feat(parser): format ini

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -318,6 +318,10 @@ func (f *ConfigurationFile) parseIniFile(file ufs.File) error {
 		return err
 	}
 
+	// Force format to be key = value
+	ini.PrettyFormat = false
+	ini.PrettyEqual = true
+
 	for _, replacement := range f.Replace {
 		var (
 			path         []string


### PR DESCRIPTION
# Changes

- Fixes this strange formatting when parsing INI files to put all = allow each other
- The forced format is now `key = value`


Before:
<img width="331" height="81" alt="afbeelding" src="https://github.com/user-attachments/assets/fa191648-1b0c-46da-a7d6-c6e144a0a33b" />
After
<img width="240" height="77" alt="afbeelding" src="https://github.com/user-attachments/assets/824adec6-6e61-44c2-8529-55c778e54a96" />


Reference: https://pkg.go.dev/gopkg.in/ini.v1?utm_source=godoc#pkg-variables


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated INI configuration file formatting to use a more compact format when saving configuration files, ensuring consistent key=value pair representation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->