### PR TITLE
Implement hard link detection in directory size calculation

### DIFF
--- a/server/filesystem/disk_space.go
+++ b/server/filesystem/disk_space.go
@@ -1,6 +1,8 @@
 package filesystem
 
 import (
+	"golang.org/x/sys/unix"
+	"slices"	
 	"sync"
 	"sync/atomic"
 	"time"
@@ -163,7 +165,9 @@ func (fs *Filesystem) DirectorySize(root string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-
+	
+	var hardLinks []uint64
+	
 	var size atomic.Int64
 	err = fs.unixFS.WalkDirat(dirfd, name, func(dirfd int, name, _ string, d ufs.DirEntry, err error) error {
 		if err != nil {
@@ -180,9 +184,17 @@ func (fs *Filesystem) DirectorySize(root string) (int64, error) {
 			return errors.Wrap(err, "lstatat err")
 		}
 
-		// TODO: detect if info is a hard-link and de-duplicate it.
-		// ref; https://github.com/pelican-dev/wings/pull/181/files
-
+		var sysFileInfo = info.Sys().(*unix.Stat_t)
+		if sysFileInfo.Nlink > 1 {
+			// Hard links have the same inode number
+			if slices.Contains(hardLinks, sysFileInfo.Ino) {
+				// Don't add hard links size twice
+				return nil
+			} else {
+				hardLinks = append(hardLinks, sysFileInfo.Ino)
+			}
+		}
+		
 		size.Add(info.Size())
 		return nil
 	})


### PR DESCRIPTION
# Changes

- Added logic to detect and handle hard links to avoid size duplication.

See: https://github.com/pterodactyl/wings/pull/181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved disk space calculation accuracy by preventing hard-linked files from being counted multiple times when determining directory sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->