### PR TITLE
Fix file ownership after egg installation

### DIFF
--- a/server/install.go
+++ b/server/install.go
@@ -202,6 +202,12 @@ func (ip *InstallationProcess) Run() error {
 		return err
 	}
 
+	// Ensure correct file ownership after installation since the install
+	// container runs as root, leaving all files owned by root:root.
+	if err := ip.Server.Filesystem().Chown("/"); err != nil {
+		ip.Server.Log().WithField("error", err).Warn("failed to chown server root directory after installation")
+	}
+
 	// If this step fails, log a warning but don't exit out of the process. This is completely
 	// internal to the daemon's functionality, and does not affect the status of the server itself.
 	if err := ip.AfterExecute(cID); err != nil {


### PR DESCRIPTION
The install container runs as root, so all files created during installation are owned by root:root. Add a chown step in InstallationProcess.Run() immediately after the container finishes to set correct ownership, regardless of CheckPermissionsOnBoot.

Fixes https://github.com/pelican-dev/panel/issues/2098

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Installation process enhanced with automatic file ownership normalization after setup completion. The system now ensures proper file permissions are applied following installation, improving system integrity and reliability. Any issues encountered during this step are logged for troubleshooting purposes, allowing the installation to continue without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->