### PR TITLE
Chown dir when creating

### DIFF
--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -424,7 +424,10 @@ func postServerCreateDirectory(c *gin.Context) {
 		middleware.CaptureAndAbort(c, err)
 		return
 	}
-
+	if err := s.Filesystem().Chown(filepath.Join(data.Path, data.Name)); err != nil {
+		middleware.CaptureAndAbort(c, err)
+		return
+	}
 	c.Status(http.StatusNoContent)
 }
 


### PR DESCRIPTION
# Changes

- Chown dir when using create directory button
- Closes #150 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Directory creation functionality has been enhanced to properly manage file ownership and permissions on newly created directories, ensuring they are created with correct access control settings and remain accessible. Directory operations now fail gracefully if ownership cannot be configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->