### PR TITLE
fix: preserve boolean/numeric types when panel expands template variables

### DIFF
--- a/parser/helpers.go
+++ b/parser/helpers.go
@@ -42,7 +42,11 @@ var xmlValueMatchRegex = regexp.MustCompile(`^\[([\w]+)='(.*)'\]$`)
 // jsonparser.Boolean. Passing the existing value lets us mirror the document's own type.
 func (cfr *ConfigurationFileReplacement) getKeyValue(value string, existing interface{}) interface{} {
 	if cfr.ReplaceWith.Type() == jsonparser.Boolean {
-		v, _ := strconv.ParseBool(value)
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			log.WithField("value", value).Warn("cannot parse replacement as boolean, falling back to string value")
+			return value
+		}
 		return v
 	}
 
@@ -51,7 +55,11 @@ func (cfr *ConfigurationFileReplacement) getKeyValue(value string, existing inte
 	if existing != nil {
 		switch existing.(type) {
 		case bool:
-			v, _ := strconv.ParseBool(value)
+			v, err := strconv.ParseBool(value)
+			if err != nil {
+				log.WithField("value", value).Warn("cannot parse replacement as boolean, falling back to string value")
+				return value
+			}
 			return v
 		case float64:
 			// encoding/json unmarshals all JSON numbers as float64.

--- a/parser/helpers.go
+++ b/parser/helpers.go
@@ -36,10 +36,29 @@ var configMatchRegex = regexp.MustCompile(`{{\s?config\.([\w.-]+)\s?}}`)
 var xmlValueMatchRegex = regexp.MustCompile(`^\[([\w]+)='(.*)'\]$`)
 
 // Gets the value of a key based on the value type defined.
-func (cfr *ConfigurationFileReplacement) getKeyValue(value string) interface{} {
+//
+// existing is the current value at that path in the document. When the panel expands a
+// template variable the result is always a JSON string, so ReplaceWith.Type() is never
+// jsonparser.Boolean. Passing the existing value lets us mirror the document's own type.
+func (cfr *ConfigurationFileReplacement) getKeyValue(value string, existing interface{}) interface{} {
 	if cfr.ReplaceWith.Type() == jsonparser.Boolean {
 		v, _ := strconv.ParseBool(value)
 		return v
+	}
+
+	// Mirror the type already present in the document so booleans and numbers survive
+	// a round-trip through template expansion.
+	if existing != nil {
+		switch existing.(type) {
+		case bool:
+			v, _ := strconv.ParseBool(value)
+			return v
+		case float64:
+			// encoding/json unmarshals all JSON numbers as float64.
+			if v, err := strconv.ParseFloat(value, 64); err == nil {
+				return v
+			}
+		}
 	}
 
 	// Try to parse into an int, if this fails just ignore the error and continue
@@ -182,7 +201,7 @@ func setValueAtPath(c *gabs.Container, path string, value interface{}) error {
 // value or not before doing it.
 func (cfr *ConfigurationFileReplacement) SetAtPathway(c *gabs.Container, path string, value string) error {
 	if cfr.IfValue == "" {
-		return setValueAtPath(c, path, cfr.getKeyValue(value))
+		return setValueAtPath(c, path, cfr.getKeyValue(value, c.Path(path).Data()))
 	}
 
 	// Check if we are replacing instead of overwriting.
@@ -211,7 +230,7 @@ func (cfr *ConfigurationFileReplacement) SetAtPathway(c *gabs.Container, path st
 		return nil
 	}
 
-	return setValueAtPath(c, path, cfr.getKeyValue(value))
+	return setValueAtPath(c, path, cfr.getKeyValue(value, c.Path(path).Data()))
 }
 
 // Looks up a configuration value on the Daemon given a dot-notated syntax.


### PR DESCRIPTION
## fix: preserve boolean and numeric types when config values come from template variables

### What's happening

When the panel builds the replacement instructions for a config file, variables like
`{{server.environment.DRY_RUN}}` get sent as plain JSON strings — `"true"` rather than
`true`. That means `ReplaceWith.Type()` is always `jsonparser.String` by the time Wings
sees it, so the boolean branch inside `getKeyValue` was never reachable.

On top of that, egg variables typed as "boolean" in the panel only produce `0` and `1`.
To actually get `true`/`false` strings you have to use an `in:true,false` validation rule
— which means the value is by definition a string, never a JSON boolean.

End result: a field that holds `true` in the config file gets overwritten with the string
`"true"`. For software that validates its config against a schema on startup (Freqtrade,
for example) that causes an immediate crash.

### The fix

`getKeyValue` now receives the value that already lives at the target path in the parsed
document. Because `gabs` uses `encoding/json` under the hood, booleans are Go `bool` and
numbers are `float64`. A simple type switch on the existing value is enough to pick the
right conversion before writing back — no guessing from the incoming string alone.

Fields that have no existing value (newly added keys) fall through to the old behaviour,
so nothing breaks for the common case.

### Before / after

The game's config file contains:

```json
"dry_run": true
```

The panel sends `"replace_with": "true"` (a string, because template expansion always produces a string).

| | Result in config file |
|---|---|
| Before | `"dry_run": "true"` ❌ string |
| After | `"dry_run": true` ✅ boolean |

### Notes

- The `ReplaceWith.Type() == jsonparser.Boolean` branch is kept for completeness but
  remains unreachable in practice — no panel sends a bare JSON boolean as the
  replacement value.
- `float64` covers both integers and floats since that is what `encoding/json` produces
  for all JSON numbers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type preservation in configuration value handling during template expansion. Boolean values and numeric values now correctly maintain their original data types when updating existing configuration properties, ensuring consistency across configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->