### PR TITLE
fix: preserve boolean/numeric types when panel expands template varia…

### DIFF
--- a/parser/helpers.go
+++ b/parser/helpers.go
@@ -40,7 +40,7 @@ func (cfr *ConfigurationFileReplacement) getKeyValue(value string) interface{} {
 	if cfr.ReplaceWith.Type() == jsonparser.Boolean {
 		v, err := strconv.ParseBool(value)
 		if err != nil {
-			log.WithField("value", value).Warn("cannot parse replacement as boolean, falling back to string value")
+			log.WithFields(log.Fields{"value": value, "match": cfr.Match}).Warn("cannot parse replacement as boolean, falling back to string value")
 			return value
 		}
 		return v
@@ -180,7 +180,7 @@ func (cfr *ConfigurationFileReplacement) setValueWithSjson(jsonStr string, path 
 		// Explicit boolean type declared in the egg definition.
 		v, err := strconv.ParseBool(value)
 		if err != nil {
-			log.WithField("value", value).Warn("cannot parse replacement as boolean, falling back to string value")
+			log.WithFields(log.Fields{"value": value, "path": path, "match": cfr.Match}).Warn("cannot parse replacement as boolean, falling back to string value")
 			return sjson.Set(jsonStr, path, value)
 		}
 		setValue = v
@@ -192,7 +192,7 @@ func (cfr *ConfigurationFileReplacement) setValueWithSjson(jsonStr string, path 
 		case gjson.True, gjson.False:
 			v, err := strconv.ParseBool(value)
 			if err != nil {
-				log.WithField("value", value).Warn("cannot parse replacement as boolean, falling back to string value")
+				log.WithFields(log.Fields{"value": value, "path": path, "match": cfr.Match}).Warn("cannot parse replacement as boolean, falling back to string value")
 				return sjson.Set(jsonStr, path, value)
 			}
 			setValue = v

--- a/parser/helpers.go
+++ b/parser/helpers.go
@@ -35,26 +35,6 @@ var configMatchRegex = regexp.MustCompile(`{{\s?config\.([\w.-]+)\s?}}`)
 // noinspection RegExpRedundantEscape
 var xmlValueMatchRegex = regexp.MustCompile(`^\[([\w]+)='(.*)'\]$`)
 
-// Gets the value of a key based on the value type defined.
-func (cfr *ConfigurationFileReplacement) getKeyValue(value string) interface{} {
-	if cfr.ReplaceWith.Type() == jsonparser.Boolean {
-		v, err := strconv.ParseBool(value)
-		if err != nil {
-			log.WithFields(log.Fields{"value": value, "match": cfr.Match}).Warn("cannot parse replacement as boolean, falling back to string value")
-			return value
-		}
-		return v
-	}
-
-	// Try to parse into an int, if this fails just ignore the error and continue
-	// through, returning the string.
-	if v, err := strconv.Atoi(value); err == nil {
-		return v
-	}
-
-	return value
-}
-
 // Iterate over an unstructured JSON/YAML/etc. interface and set all of the required
 // key/value pairs for the configuration file.
 //

--- a/parser/helpers.go
+++ b/parser/helpers.go
@@ -197,11 +197,13 @@ func (cfr *ConfigurationFileReplacement) setValueWithSjson(jsonStr string, path 
 			}
 			setValue = v
 		case gjson.Number:
-			if v, err := strconv.ParseFloat(value, 64); err == nil {
-				setValue = v
-			} else {
-				setValue = value
+			// Write the numeric literal as-is via SetRaw to avoid float64 precision
+			// loss for large integers (> 2^53). Fall back to string if the incoming
+			// value is not a valid JSON number.
+			if gjson.Parse(value).Type == gjson.Number {
+				return sjson.SetRaw(jsonStr, path, value)
 			}
+			setValue = value
 		default:
 			if v, err := strconv.Atoi(value); err == nil {
 				setValue = v

--- a/parser/helpers.go
+++ b/parser/helpers.go
@@ -38,7 +38,11 @@ var xmlValueMatchRegex = regexp.MustCompile(`^\[([\w]+)='(.*)'\]$`)
 // Gets the value of a key based on the value type defined.
 func (cfr *ConfigurationFileReplacement) getKeyValue(value string) interface{} {
 	if cfr.ReplaceWith.Type() == jsonparser.Boolean {
-		v, _ := strconv.ParseBool(value)
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			log.WithField("value", value).Warn("cannot parse replacement as boolean, falling back to string value")
+			return value
+		}
 		return v
 	}
 
@@ -173,12 +177,38 @@ func (cfr *ConfigurationFileReplacement) setValueWithSjson(jsonStr string, path 
 
 	var setValue interface{}
 	if cfr.ReplaceWith.Type() == jsonparser.Boolean {
-		v, _ := strconv.ParseBool(value)
-		setValue = v
-	} else if v, err := strconv.Atoi(value); err == nil {
+		// Explicit boolean type declared in the egg definition.
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			log.WithField("value", value).Warn("cannot parse replacement as boolean, falling back to string value")
+			return sjson.Set(jsonStr, path, value)
+		}
 		setValue = v
 	} else {
-		setValue = value
+		// Mirror the type already present in the document so booleans and numbers
+		// survive template expansion (panel always sends values as JSON strings).
+		existing := gjson.Get(jsonStr, path)
+		switch existing.Type {
+		case gjson.True, gjson.False:
+			v, err := strconv.ParseBool(value)
+			if err != nil {
+				log.WithField("value", value).Warn("cannot parse replacement as boolean, falling back to string value")
+				return sjson.Set(jsonStr, path, value)
+			}
+			setValue = v
+		case gjson.Number:
+			if v, err := strconv.ParseFloat(value, 64); err == nil {
+				setValue = v
+			} else {
+				setValue = value
+			}
+		default:
+			if v, err := strconv.Atoi(value); err == nil {
+				setValue = v
+			} else {
+				setValue = value
+			}
+		}
 	}
 
 	return sjson.Set(jsonStr, path, setValue)


### PR DESCRIPTION
## fix: preserve boolean and numeric types when config values come from template variables

### What's happening

When the panel builds the replacement instructions for a config file, variables like
`{{server.environment.DRY_RUN}}` get sent as plain JSON strings — `"true"` rather than
`true`. That means `ReplaceWith.Type()` is always `jsonparser.String` by the time Wings
sees it, so the boolean branch inside `getKeyValue` was never reachable.

On top of that, egg variables typed as "boolean" in the panel only produce `0` and `1`.
To actually get `true`/`false` strings you have to use an `in:true,false` validation rule
— which means the value is by definition a string, never a JSON boolean.

End result: a field that holds `true` in the config file gets overwritten with the string
`"true"`. For software that validates its config against a schema on startup (Freqtrade,
for example) that causes an immediate crash.

### The fix

`getKeyValue` now receives the value that already lives at the target path in the parsed
document. Because `gabs` uses `encoding/json` under the hood, booleans are Go `bool` and
numbers are `float64`. A simple type switch on the existing value is enough to pick the
right conversion before writing back — no guessing from the incoming string alone.

Fields that have no existing value (newly added keys) fall through to the old behaviour,
so nothing breaks for the common case.

### Before / after

The game's config file contains:

```json
"dry_run": true
```

The panel sends `"replace_with": "true"` (a string, because template expansion always produces a string).

| | Result in config file |
|---|---|
| Before | `"dry_run": "true"` ❌ string |
| After | `"dry_run": true` ✅ boolean |

### Notes

- The `ReplaceWith.Type() == jsonparser.Boolean` branch is kept for completeness but
  remains unreachable in practice — no panel sends a bare JSON boolean as the
  replacement value.
- `float64` covers both integers and floats since that is what `encoding/json` produces
  for all JSON numbers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type preservation in configuration value handling during template expansion. Boolean values and numeric values now correctly maintain their original data types when updating existing configuration properties, ensuring consistency across configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->