### PR TITLE
fix: parser correctness fixes (integer precision, nil safety, multi-variable lookup, type coercion, IfValue, XML duplicates)

### DIFF
--- a/parser/helpers.go
+++ b/parser/helpers.go
@@ -204,8 +204,11 @@ func (f *ConfigurationFile) LookupConfigurationValue(cfr ConfigurationFileReplac
 	// If there is a match, lookup the value in the configuration for the Daemon. If no key
 	// is found, just return the string representation, otherwise use the value from the
 	// daemon configuration here.
-	result := cfr.ReplaceWith.String()
-	for _, placeholder := range configMatchRegex.FindAllString(result, -1) {
+	var lookupErr error
+	result := configMatchRegex.ReplaceAllStringFunc(cfr.ReplaceWith.String(), func(placeholder string) string {
+		if lookupErr != nil {
+			return placeholder
+		}
 		keyPath := configMatchRegex.ReplaceAllString(placeholder, "$1")
 
 		var path []string
@@ -217,13 +220,14 @@ func (f *ConfigurationFile) LookupConfigurationValue(cfr ConfigurationFileReplac
 		match, _, _, err := jsonparser.Get(f.configuration, path...)
 		if err != nil {
 			if err != jsonparser.KeyPathNotFoundError {
-				return result, err
+				lookupErr = err
+				return placeholder
 			}
 			log.WithFields(log.Fields{"path": path, "filename": f.FileName}).Debug("attempted to load a configuration value that does not exist")
 			// Leave placeholder intact so the misconfiguration is visible.
-			continue
+			return placeholder
 		}
-		result = strings.Replace(result, placeholder, string(match), 1)
-	}
-	return result, nil
+		return string(match)
+	})
+	return result, lookupErr
 }

--- a/parser/helpers.go
+++ b/parser/helpers.go
@@ -185,11 +185,7 @@ func (cfr *ConfigurationFileReplacement) setValueWithSjson(jsonStr string, path 
 			}
 			setValue = value
 		default:
-			if v, err := strconv.Atoi(value); err == nil {
-				setValue = v
-			} else {
-				setValue = value
-			}
+			setValue = value
 		}
 	}
 
@@ -208,29 +204,26 @@ func (f *ConfigurationFile) LookupConfigurationValue(cfr ConfigurationFileReplac
 	// If there is a match, lookup the value in the configuration for the Daemon. If no key
 	// is found, just return the string representation, otherwise use the value from the
 	// daemon configuration here.
-	huntPath := configMatchRegex.ReplaceAllString(
-		configMatchRegex.FindString(cfr.ReplaceWith.String()), "$1",
-	)
+	result := cfr.ReplaceWith.String()
+	for _, placeholder := range configMatchRegex.FindAllString(result, -1) {
+		keyPath := configMatchRegex.ReplaceAllString(placeholder, "$1")
 
-	var path []string
-	for _, value := range strings.Split(huntPath, ".") {
-		path = append(path, strcase.ToSnake(value))
-	}
-
-	// Look for the key in the configuration file, and if found return that value to the
-	// calling function.
-	match, _, _, err := jsonparser.Get(f.configuration, path...)
-	if err != nil {
-		if err != jsonparser.KeyPathNotFoundError {
-			return string(match), err
+		var path []string
+		for _, part := range strings.Split(keyPath, ".") {
+			path = append(path, strcase.ToSnake(part))
 		}
 
-		log.WithFields(log.Fields{"path": path, "filename": f.FileName}).Debug("attempted to load a configuration value that does not exist")
-
-		// If there is no key, keep the original value intact, that way it is obvious there
-		// is a replace issue at play.
-		return string(match), nil
-	} else {
-		return configMatchRegex.ReplaceAllString(cfr.ReplaceWith.String(), string(match)), nil
+		// Look for the key in the Wings configuration and substitute the placeholder.
+		match, _, _, err := jsonparser.Get(f.configuration, path...)
+		if err != nil {
+			if err != jsonparser.KeyPathNotFoundError {
+				return result, err
+			}
+			log.WithFields(log.Fields{"path": path, "filename": f.FileName}).Debug("attempted to load a configuration value that does not exist")
+			// Leave placeholder intact so the misconfiguration is visible.
+			continue
+		}
+		result = strings.Replace(result, placeholder, string(match), 1)
 	}
+	return result, nil
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -462,9 +462,12 @@ func (f *ConfigurationFile) parseYamlFile(file ufs.File) error {
 	}
 
 	var jsonData interface{}
-	if err := json.Unmarshal(data, &jsonData); err != nil {
+	yamlDecoder := json.NewDecoder(bytes.NewReader(data))
+	yamlDecoder.UseNumber()
+	if err := yamlDecoder.Decode(&jsonData); err != nil {
 		return err
 	}
+	jsonData = normalizeYamlTypes(jsonData)
 
 	marshaled, err := yaml.Marshal(jsonData)
 	if err != nil {
@@ -534,6 +537,34 @@ func (f *ConfigurationFile) parseTomlFile(file ufs.File) error {
 		return errors.Wrap(err, "parser: failed to write toml file to disk")
 	}
 	return nil
+}
+
+// normalizeYamlTypes converts json.Number values (produced by UseNumber()) into
+// proper Go numeric types so that yaml.Marshal writes integers as plain integers
+// instead of float64 scientific notation (e.g. 1.5e+18 for large Snowflake IDs).
+func normalizeYamlTypes(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		for key, item := range typed {
+			typed[key] = normalizeYamlTypes(item)
+		}
+		return typed
+	case []interface{}:
+		for i := range typed {
+			typed[i] = normalizeYamlTypes(typed[i])
+		}
+		return typed
+	case json.Number:
+		if intVal, err := typed.Int64(); err == nil {
+			return intVal
+		}
+		if floatVal, err := typed.Float64(); err == nil {
+			return floatVal
+		}
+		return typed.String()
+	default:
+		return value
+	}
 }
 
 func normalizeTomlTypes(value interface{}) interface{} {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -144,13 +144,11 @@ func (f *ConfigurationFile) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	f.Replace = []ConfigurationFileReplacement{}
 	if replaceRaw, ok := m["replace"]; ok && replaceRaw != nil {
 		if err := json.Unmarshal(*replaceRaw, &f.Replace); err != nil {
 			log.WithField("file", f.FileName).WithField("error", err).Warn("failed to unmarshal configuration file replacement")
-			f.Replace = []ConfigurationFileReplacement{}
 		}
-	} else {
-		f.Replace = []ConfigurationFileReplacement{}
 	}
 
 	// test if "create_file" exists, if not just assume true
@@ -567,13 +565,22 @@ func normalizeYamlTypes(value interface{}) interface{} {
 		}
 		return typed
 	case json.Number:
+		s := typed.String()
+		// Preserve float representation: if the number contains '.', 'e' or 'E'
+		// it was originally a float and must not be coerced to int64.
+		if strings.ContainsAny(s, ".eE") {
+			if floatVal, err := typed.Float64(); err == nil {
+				return floatVal
+			}
+			return s
+		}
 		if intVal, err := typed.Int64(); err == nil {
 			return intVal
 		}
 		if floatVal, err := typed.Float64(); err == nil {
 			return floatVal
 		}
-		return typed.String()
+		return s
 	default:
 		return value
 	}
@@ -629,8 +636,10 @@ func (f *ConfigurationFile) parseTextFile(file ufs.File) error {
 				continue
 			}
 			// If an if_value is set, only replace when the remainder of the line matches.
+			// Trim trailing \r\n so Windows line endings do not break the comparison.
 			if replace.IfValue != "" {
-				if string(bytes.TrimPrefix(line, []byte(replace.Match))) != replace.IfValue {
+				remainder := bytes.TrimRight(bytes.TrimPrefix(line, []byte(replace.Match)), "\r\n")
+				if string(remainder) != replace.IfValue {
 					continue
 				}
 			}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -128,17 +128,28 @@ func (f *ConfigurationFile) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if err := json.Unmarshal(*m["file"], &f.FileName); err != nil {
+	fileRaw, ok := m["file"]
+	if !ok || fileRaw == nil {
+		return errors.New("parser: configuration file missing required 'file' key")
+	}
+	if err := json.Unmarshal(*fileRaw, &f.FileName); err != nil {
 		return err
 	}
 
-	if err := json.Unmarshal(*m["parser"], &f.Parser); err != nil {
+	parserRaw, ok := m["parser"]
+	if !ok || parserRaw == nil {
+		return errors.New("parser: configuration file missing required 'parser' key")
+	}
+	if err := json.Unmarshal(*parserRaw, &f.Parser); err != nil {
 		return err
 	}
 
-	if err := json.Unmarshal(*m["replace"], &f.Replace); err != nil {
-		log.WithField("file", f.FileName).WithField("error", err).Warn("failed to unmarshal configuration file replacement")
-
+	if replaceRaw, ok := m["replace"]; ok && replaceRaw != nil {
+		if err := json.Unmarshal(*replaceRaw, &f.Replace); err != nil {
+			log.WithField("file", f.FileName).WithField("error", err).Warn("failed to unmarshal configuration file replacement")
+			f.Replace = []ConfigurationFileReplacement{}
+		}
+	} else {
 		f.Replace = []ConfigurationFileReplacement{}
 	}
 
@@ -292,6 +303,7 @@ func (f *ConfigurationFile) parseXmlFile(file ufs.File) error {
 				k := xmlValueMatchRegex.ReplaceAllString(value, "$1")
 				v := xmlValueMatchRegex.ReplaceAllString(value, "$2")
 
+				element.RemoveAttr(k)
 				element.CreateAttr(k, v)
 			} else {
 				element.SetText(value)
@@ -615,6 +627,12 @@ func (f *ConfigurationFile) parseTextFile(file ufs.File) error {
 			// line. Otherwise, update the line to have the replacement value.
 			if !bytes.HasPrefix(line, []byte(replace.Match)) {
 				continue
+			}
+			// If an if_value is set, only replace when the remainder of the line matches.
+			if replace.IfValue != "" {
+				if string(bytes.TrimPrefix(line, []byte(replace.Match))) != replace.IfValue {
+					continue
+				}
 			}
 			b.Write(replace.ReplaceWith.Bytes())
 			replaced = true


### PR DESCRIPTION
### Summary

This PR fixes six bugs in the configuration file parser (`parser/parser.go`, `parser/helpers.go`).

---

### Changes

#### 1. YAML: Preserve integer precision for large values (`parser.go`)

`json.Unmarshal` without `UseNumber()` converts integers larger than 2⁵³ to `float64`, causing precision loss. For example, a Snowflake ID like `150553673164927820` would be written to disk as `1.5055367316492782e+18`.

The TOML parser already used `UseNumber()` correctly — this fix applies the same approach to the YAML parser: use `json.NewDecoder` with `UseNumber()` and a new `normalizeYamlTypes()` function that converts `json.Number` values to proper `int64`/`float64` before marshalling back to YAML.

#### 2. `UnmarshalJSON`: nil pointer dereference on incomplete egg config (`parser.go`)

If a configuration file entry from the panel was missing the `file` or `parser` keys, Wings would panic with a nil pointer dereference. Added explicit `ok` checks before dereferencing map values and return a descriptive error instead.

#### 3. `LookupConfigurationValue`: only first placeholder resolved (`helpers.go`)

When a `replace_with` value contained multiple `{{ config.x }}` placeholders (e.g. `{{ config.uuid }}-{{ config.port }}`), only the first one was looked up and its value was substituted for **all** placeholders. Replaced the single `ReplaceAllString` call with a loop over `FindAllString` that resolves and substitutes each placeholder individually.

#### 4. `setValueWithSjson`: string values silently coerced to integers (`helpers.go`)

The default case in `setValueWithSjson` called `strconv.Atoi` on string values and stored the integer result if successful. This caused string values like `"25565"` to be written as the integer `25565`, changing the type of the value in config files unexpectedly. Removed the coercion — strings are now always stored as strings.

#### 5. `parseTextFile`: `IfValue` condition never evaluated (`parser.go`)

The `IfValue` field on a replacement rule was never checked in the plain-text file parser. Lines were always replaced regardless of the current value. Added an explicit check: if `IfValue` is set, skip the replacement unless the current value of that line matches.

#### 6. `parseXmlFile`: duplicate attributes on repeated runs (`parser.go`)

`etree.CreateAttr` does not overwrite an existing attribute — it appends a second one. On every Wings restart, XML config files would accumulate duplicate attributes. Added `element.RemoveAttr(k)` before `element.CreateAttr(k, v)` to ensure idempotent writes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Multiple configuration placeholders within the same replacement string now process correctly
  * YAML numeric types now parse and normalize properly  
  * Text file replacements now respect conditional value matching
  * Missing configuration keys no longer halt placeholder processing

* **Refactor**
  * Improved configuration file validation and error handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pelican-dev/wings/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->