### PR TITLE
Add quiet config option

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -110,7 +110,9 @@ func isDockerSnap() bool {
 }
 
 func rootCmdRun(cmd *cobra.Command, _ []string) {
-	printLogo()
+	if config.Get().Debug || !config.Get().Quiet {
+		printLogo()
+	}
 	log.Debug("running in debug mode")
 	log.WithField("config_file", configPath).Info("loading configuration from file")
 
@@ -451,6 +453,8 @@ func initLogging() {
 	log.SetLevel(log.InfoLevel)
 	if config.Get().Debug {
 		log.SetLevel(log.DebugLevel)
+	} else if config.Get().Quiet {
+		log.SetLevel(log.WarnLevel)
 	}
 	log.SetHandler(multi.New(cli.Default, cli.New(w.File, false)))
 	log.WithField("path", p).Info("writing log files to disk")

--- a/config/config.go
+++ b/config/config.go
@@ -328,6 +328,10 @@ type Configuration struct {
 	// if the debug flag is passed through the command line arguments.
 	Debug bool
 
+	// Determines if wings should run with minimal logging output. This value is
+	// ignored if debug mode is enabled.
+	Quiet bool
+
 	AppName string `default:"pelican" json:"app_name" yaml:"app_name"`
 
 	// A unique identifier for this node in the Panel.


### PR DESCRIPTION
Useful when running as a systemd service, prevents journal polution. Alternative is a log-level option, but that would conflict with the already existing debug flag. I'll leave the choice up to the maintainers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Quiet mode setting to enable minimal logging output while preserving full debug behavior.
* **Behavior Changes**
  * When Quiet mode is active (and not in debug), the app suppresses non-critical messages and the startup logo, and reduces logging to warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->