### PR TITLE
Do not follow symlinks when performing chmod operations

### DIFF
--- a/internal/ufs/fs_unix.go
+++ b/internal/ufs/fs_unix.go
@@ -90,7 +90,7 @@ func (fs *UnixFS) Chmodat(dirfd int, name string, mode FileMode) error {
 }
 
 func (fs *UnixFS) fchmodat(op string, dirfd int, name string, mode FileMode) error {
-	return ensurePathError(unix.Fchmodat(dirfd, name, uint32(mode), 0), op, name)
+	return ensurePathError(unix.Fchmodat(dirfd, name, uint32(mode), AT_SYMLINK_NOFOLLOW), op, name)
 }
 
 // Chown changes the numeric uid and gid of the named file.


### PR DESCRIPTION
# Changes

- https://github.com/pterodactyl/wings/security/advisories/GHSA-rhq6-9rgh-v45c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File permission changes no longer follow symbolic links, ensuring permissions are applied directly to the symbolic link itself rather than its target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->