### PR TITLE
fix(parser): write numeric/bool values unquoted for newly created config files

### DIFF
--- a/parser/helpers.go
+++ b/parser/helpers.go
@@ -35,6 +35,20 @@ var configMatchRegex = regexp.MustCompile(`{{\s?config\.([\w.-]+)\s?}}`)
 // noinspection RegExpRedundantEscape
 var xmlValueMatchRegex = regexp.MustCompile(`^\[([\w]+)='(.*)'\]$`)
 
+// jsonNumberRegex matches a canonical JSON number exactly as defined by the JSON
+// grammar. We deliberately use this instead of gjson.Parse/json.Valid, which
+// accept lax forms such as "007", "+5", "1.20.1" or "25565x". A value is only
+// written unquoted via sjson.SetRaw when it matches this pattern, guaranteeing
+// the result is valid JSON and the exact literal (including large integers) is
+// preserved.
+var jsonNumberRegex = regexp.MustCompile(`^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$`)
+
+// isJSONNumber reports whether s is a canonical JSON number that is safe to write
+// unquoted into a document.
+func isJSONNumber(s string) bool {
+	return jsonNumberRegex.MatchString(s)
+}
+
 // Iterate over an unstructured JSON/YAML/etc. interface and set all of the required
 // key/value pairs for the configuration file.
 //
@@ -156,7 +170,8 @@ func (cfr *ConfigurationFileReplacement) setValueWithSjson(jsonStr string, path 
 	}
 
 	var setValue interface{}
-	if cfr.ReplaceWith.Type() == jsonparser.Boolean {
+	switch {
+	case cfr.ReplaceWith.Type() == jsonparser.Boolean:
 		// Explicit boolean type declared in the egg definition.
 		v, err := strconv.ParseBool(value)
 		if err != nil {
@@ -164,26 +179,41 @@ func (cfr *ConfigurationFileReplacement) setValueWithSjson(jsonStr string, path 
 			return sjson.Set(jsonStr, path, value)
 		}
 		setValue = v
-	} else {
-		// Mirror the type already present in the document so booleans and numbers
-		// survive template expansion (panel always sends values as JSON strings).
+	case cfr.ReplaceWith.Type() == jsonparser.Number && isJSONNumber(value):
+		// Explicit numeric type declared in the egg definition. Write the literal
+		// as-is via SetRaw to avoid float64 precision loss for large integers (> 2^53).
+		return sjson.SetRaw(jsonStr, path, value)
+	default:
+		// The panel expands template variables and sends every value as a JSON
+		// string, so mirror the type already present in the document where possible
+		// to keep booleans and numbers unquoted.
 		existing := gjson.Get(jsonStr, path)
-		switch existing.Type {
-		case gjson.True, gjson.False:
+		switch {
+		case existing.Type == gjson.True || existing.Type == gjson.False:
 			v, err := strconv.ParseBool(value)
 			if err != nil {
 				log.WithFields(log.Fields{"value": value, "path": path, "match": cfr.Match}).Warn("cannot parse replacement as boolean, falling back to string value")
 				return sjson.Set(jsonStr, path, value)
 			}
 			setValue = v
-		case gjson.Number:
+		case existing.Type == gjson.Number && isJSONNumber(value):
 			// Write the numeric literal as-is via SetRaw to avoid float64 precision
-			// loss for large integers (> 2^53). Fall back to string if the incoming
-			// value is not a valid JSON number.
-			if gjson.Parse(value).Type == gjson.Number {
+			// loss for large integers (> 2^53).
+			return sjson.SetRaw(jsonStr, path, value)
+		case !existing.Exists():
+			// The key does not exist yet. This is the common case when a server is
+			// first created and its configuration file is generated from scratch:
+			// there is no existing type to mirror. Infer the natural type from the
+			// value itself so numeric values such as ports are written unquoted
+			// (e.g. `server-port: 25565` instead of `server-port: "25565"`).
+			switch {
+			case value == "true" || value == "false":
+				setValue = value == "true"
+			case isJSONNumber(value):
 				return sjson.SetRaw(jsonStr, path, value)
+			default:
+				setValue = value
 			}
-			setValue = value
 		default:
 			setValue = value
 		}

--- a/parser/helpers.go
+++ b/parser/helpers.go
@@ -174,10 +174,9 @@ func (cfr *ConfigurationFileReplacement) setValueWithSjson(jsonStr string, path 
 	case cfr.ReplaceWith.Type() == jsonparser.Boolean:
 		// Explicit boolean type declared in the egg definition.
 		return cfr.setBool(jsonStr, path, value)
-	case cfr.ReplaceWith.Type() == jsonparser.Number && isJSONNumber(value):
-		// Explicit numeric type declared in the egg definition. Write the literal
-		// as-is via SetRaw to avoid float64 precision loss for large integers (> 2^53).
-		return sjson.SetRaw(jsonStr, path, value)
+	case cfr.ReplaceWith.Type() == jsonparser.Number:
+		// Explicit numeric type declared in the egg definition.
+		return cfr.setNumber(jsonStr, path, value)
 	default:
 		// The panel expands template variables and sends every value as a JSON
 		// string, so mirror the type already present in the document where possible
@@ -222,6 +221,19 @@ func (cfr *ConfigurationFileReplacement) setBool(jsonStr, path, value string) (s
 		return sjson.Set(jsonStr, path, value)
 	}
 	return sjson.Set(jsonStr, path, v)
+}
+
+// setNumber writes a canonical JSON number to path unquoted via SetRaw to avoid
+// float64 precision loss for large integers (> 2^53). If value is not a canonical
+// JSON number it logs a warning and falls back to writing the raw string, so a
+// misconfigured egg that declares a numeric type for a non-numeric value is
+// diagnosable (mirroring setBool).
+func (cfr *ConfigurationFileReplacement) setNumber(jsonStr, path, value string) (string, error) {
+	if !isJSONNumber(value) {
+		log.WithFields(log.Fields{"value": value, "path": path, "match": cfr.Match}).Warn("cannot parse replacement as number, falling back to string value")
+		return sjson.Set(jsonStr, path, value)
+	}
+	return sjson.SetRaw(jsonStr, path, value)
 }
 
 // Looks up a configuration value on the Daemon given a dot-notated syntax.

--- a/parser/helpers.go
+++ b/parser/helpers.go
@@ -173,12 +173,7 @@ func (cfr *ConfigurationFileReplacement) setValueWithSjson(jsonStr string, path 
 	switch {
 	case cfr.ReplaceWith.Type() == jsonparser.Boolean:
 		// Explicit boolean type declared in the egg definition.
-		v, err := strconv.ParseBool(value)
-		if err != nil {
-			log.WithFields(log.Fields{"value": value, "path": path, "match": cfr.Match}).Warn("cannot parse replacement as boolean, falling back to string value")
-			return sjson.Set(jsonStr, path, value)
-		}
-		setValue = v
+		return cfr.setBool(jsonStr, path, value)
 	case cfr.ReplaceWith.Type() == jsonparser.Number && isJSONNumber(value):
 		// Explicit numeric type declared in the egg definition. Write the literal
 		// as-is via SetRaw to avoid float64 precision loss for large integers (> 2^53).
@@ -190,12 +185,7 @@ func (cfr *ConfigurationFileReplacement) setValueWithSjson(jsonStr string, path 
 		existing := gjson.Get(jsonStr, path)
 		switch {
 		case existing.Type == gjson.True || existing.Type == gjson.False:
-			v, err := strconv.ParseBool(value)
-			if err != nil {
-				log.WithFields(log.Fields{"value": value, "path": path, "match": cfr.Match}).Warn("cannot parse replacement as boolean, falling back to string value")
-				return sjson.Set(jsonStr, path, value)
-			}
-			setValue = v
+			return cfr.setBool(jsonStr, path, value)
 		case existing.Type == gjson.Number && isJSONNumber(value):
 			// Write the numeric literal as-is via SetRaw to avoid float64 precision
 			// loss for large integers (> 2^53).
@@ -220,6 +210,18 @@ func (cfr *ConfigurationFileReplacement) setValueWithSjson(jsonStr string, path 
 	}
 
 	return sjson.Set(jsonStr, path, setValue)
+}
+
+// setBool parses value as a boolean and writes it to path unquoted. If value is
+// not a valid boolean it logs a warning and falls back to writing the raw string,
+// keeping the explicit-type and mirror-existing-type boolean paths in sync.
+func (cfr *ConfigurationFileReplacement) setBool(jsonStr, path, value string) (string, error) {
+	v, err := strconv.ParseBool(value)
+	if err != nil {
+		log.WithFields(log.Fields{"value": value, "path": path, "match": cfr.Match}).Warn("cannot parse replacement as boolean, falling back to string value")
+		return sjson.Set(jsonStr, path, value)
+	}
+	return sjson.Set(jsonStr, path, v)
 }
 
 // Looks up a configuration value on the Daemon given a dot-notated syntax.


### PR DESCRIPTION
## Problem

When a server is created for the first time, its configuration file is often generated from scratch, so the target key does not exist yet. `setValueWithSjson` (parser/helpers.go) previously inferred a value's type **solely by mirroring the type already present in the document**. A freshly created key therefore has no existing type to mirror, and every value falls back to a quoted string.

As a result numeric values such as ports are written quoted:

```yaml
server-port: "25565"   # before
server-port: 25565     # expected
```

The same applies to booleans and to JSON/TOML output. This breaks games/servers that require a real number (or boolean) for those keys.

## Fix

In `setValueWithSjson`:

- **New key (`!existing.Exists()`)** — infer the natural type from the value itself, writing clean JSON numbers and booleans unquoted (`SetRaw` for numbers to preserve large-integer precision).
- **Explicit numeric type from the egg** is now honoured, mirroring the existing handling of an explicit boolean type (previously only booleans were honoured).
- **Strict canonical JSON-number check** (`isJSONNumber`) replaces the lax `gjson.Parse` check. `gjson.Parse` treats values like `007`, `+5`, `1.20.1` and `25565x` as numbers, which would coerce them incorrectly and could even produce **invalid JSON** via `SetRaw`. The new regex matches the JSON number grammar exactly, so those stay strings.

Existing string-typed keys are intentionally left untouched, so values like a numeric password in an existing template are **not** coerced to numbers — this keeps the change low-risk and avoids regressions.

## Verification

`go build` and `go vet` pass. Verified behaviour (new-key and existing-key paths):

| Input (`{}` unless noted) | Result |
| --- | --- |
| new `server-port` = `"25565"` | `25565` ✅ (the reported bug) |
| new `online-mode` = `"true"` | `true` ✅ |
| new `motd` = `"Welcome"` | `"Welcome"` ✅ |
| new `id` = `"007"` | `"007"` ✅ (leading zero preserved) |
| new `key` = `"25565x"` | `"25565x"` ✅ |
| new `owner` = `"1234567890123456789"` | `1234567890123456789` ✅ (precise) |
| existing `{"pass":"old"}` ← `"12345"` | `"12345"` ✅ (no regression) |
| existing `{"port":1}` ← `"25565"` | `25565` ✅ |
| existing `{"flag":false}` ← `"true"` | `true` ✅ |
| explicit egg Number `100` | `100` ✅ |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of numeric configuration replacements with strict validation of canonical JSON number formats, including exponent notation.
  * Boolean replacements now parse more reliably; when values aren’t valid booleans, they fall back safely to preserve the original string.
  * Numeric detection is tightened for both mirrored existing numeric fields and newly created keys, reducing cases where numbers were written with incorrect quoting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->