### PR TITLE
fix(download): allow signed download tokens to be reused until they expire

### DIFF
--- a/router/router_download.go
+++ b/router/router_download.go
@@ -28,7 +28,7 @@ func getDownloadBackup(c *gin.Context) {
 	}
 
 	// Get the server using the UUID from the token.
-	if _, ok := manager.Get(token.ServerUuid); !ok || !token.IsUniqueRequest() || !token.HasScope(tokens.BackupDownload) {
+	if _, ok := manager.Get(token.ServerUuid); !ok || !token.HasScope(tokens.BackupDownload) {
 		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
 			"error": "The requested resource was not found on this server.",
 		})
@@ -82,7 +82,7 @@ func getDownloadFile(c *gin.Context) {
 	}
 
 	s, ok := manager.Get(token.ServerUuid)
-	if !ok || !token.IsUniqueRequest() || !token.HasScope(tokens.FileDownload) {
+	if !ok || !token.HasScope(tokens.FileDownload) {
 		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
 			"error": "The requested resource was not found on this server.",
 		})


### PR DESCRIPTION
Fixes #196.

### Problem

Backup and file download URLs are single-use: `getDownloadBackup` and `getDownloadFile` require `token.IsUniqueRequest()`, which marks the token's `unique_id` as spent on first use. Any second request to the same signed URL then returns `404 {"error":"The requested resource was not found on this server."}`, aborting the download.

This breaks common, legitimate clients that request the URL more than once:

- browser download safe-browsing / virus scanning (Brave, Chrome/Edge SmartScreen),
- antivirus software,
- download managers / range requests,
- a reconnect near the end of a large download (there is no Range/resume support).

### Change

Remove the one-time-use (`IsUniqueRequest`) requirement from the two **download** handlers (`getDownloadBackup`, `getDownloadFile`). Download authorization now relies on the JWT signature, expiry (`exp`), scope, and server match. One-time use is kept for **uploads** (`FileUpload`), where replay protection is appropriate.

```diff
-	if _, ok := manager.Get(token.ServerUuid); !ok || !token.IsUniqueRequest() || !token.HasScope(tokens.BackupDownload) {
+	if _, ok := manager.Get(token.ServerUuid); !ok || !token.HasScope(tokens.BackupDownload) {
```
```diff
-	if !ok || !token.IsUniqueRequest() || !token.HasScope(tokens.FileDownload) {
+	if !ok || !token.HasScope(tokens.FileDownload) {
```

### Why it's safe

Download URLs are short-lived signed JWTs, scoped to a single backup/file and server, and downloads are idempotent GETs. Allowing reuse within the token's TTL matches the behaviour of the S3 backup adapter, which already returns a reusable presigned URL.

This leaves `BackupPayload.IsUniqueRequest` and `FilePayload.IsUniqueRequest` unused; happy to remove those (and trim the token store) if preferred — kept the diff minimal for review.

### Testing

- Before: requesting a signed backup URL twice returns `200` then `404`; after, both return `200` until the token expires.
- The complete file streams correctly in a single request in both cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download handling so backup and file downloads are accepted in more valid cases when the server is available.
  * Reduced unnecessary download rejections, helping legitimate download requests complete more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->