### PR TITLE
Use filepath.Base when transfering backups

### DIFF
--- a/router/router_transfer.go
+++ b/router/router_transfer.go
@@ -263,7 +263,9 @@ out:
 				trnsfr.Log().WithField("path", installLogPath).Debug("install logs saved successfully")
 
 			case strings.HasPrefix(name, "backup_"):
-				backupName := strings.TrimPrefix(name, "backup_")
+				backupNameUnsafe := strings.TrimPrefix(name, "backup_")
+				// Strip all directory components
+				backupName := filepath.Base(backupNameUnsafe)
 				trnsfr.Log().WithField("backup", backupName).Debug("received backup file")
 
 				// Create backup directory if it doesn't exist


### PR DESCRIPTION
# Changes

- Validate that the backupname is within the base path when transfering backups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup file handling by removing directory components from uploaded filenames.
  * Ensured backup storage and checksum verification use the sanitized filename.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->