### PR TITLE
fix(backups): Every server has its own backup dir

### DIFF
--- a/router/router_download.go
+++ b/router/router_download.go
@@ -43,7 +43,7 @@ func getDownloadBackup(c *gin.Context) {
 	}
 
 	// Locate the backup on the local disk.
-	b, st, err := backup.LocateLocal(client, token.BackupUuid)
+	b, st, err := backup.LocateLocal(client, token.BackupUuid, token.ServerUuid)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{

--- a/router/router_server_backup.go
+++ b/router/router_server_backup.go
@@ -56,9 +56,9 @@ func postServerBackup(c *gin.Context) {
 	var adapter backup.BackupInterface
 	switch data.Adapter {
 	case backup.LocalBackupAdapter:
-		adapter = backup.NewLocal(client, backupUuid, data.Ignore)
+		adapter = backup.NewLocal(client, backupUuid, s.ID(), data.Ignore)
 	case backup.S3BackupAdapter:
-		adapter = backup.NewS3(client, backupUuid, data.Ignore)
+		adapter = backup.NewS3(client, backupUuid, s.ID(), data.Ignore)
 	default:
 		middleware.CaptureAndAbort(c, errors.New("router/backups: provided adapter is not valid: "+string(data.Adapter)))
 		return
@@ -137,11 +137,10 @@ func postServerRestoreBackup(c *gin.Context) {
 		}
 	}
 
-
 	// Now that we've cleaned up the data directory if necessary, grab the backup file
 	// and attempt to restore it into the server directory.
 	if data.Adapter == backup.LocalBackupAdapter {
-		b, _, err := backup.LocateLocal(client, backupUuid)
+		b, _, err := backup.LocateLocal(client, backupUuid, s.ID())
 		if err != nil {
 			middleware.CaptureAndAbort(c, err)
 			return
@@ -182,7 +181,7 @@ func postServerRestoreBackup(c *gin.Context) {
 		if stderrors.As(err, &downloadErr) {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": downloadErr.Error()})
 			return
-		}		
+		}
 		middleware.CaptureAndAbort(c, err)
 		return
 	}
@@ -190,7 +189,7 @@ func postServerRestoreBackup(c *gin.Context) {
 		_ = res.Body.Close()
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "The provided backup link returned an invalid response status: " + res.Status})
 		return
-	}	
+	}
 	// Don't allow content types that we know are going to give us problems.
 	if !isSupportedBackupRestoreContentType(res.Header.Get("Content-Type")) {
 		_ = res.Body.Close()
@@ -202,7 +201,7 @@ func postServerRestoreBackup(c *gin.Context) {
 
 	go func(s *server.Server, uuid string, logger *log.Entry) {
 		logger.Info("starting restoration process for server backup using S3 driver")
-		if err := s.RestoreBackup(backup.NewS3(client, uuid, ""), res.Body); err != nil {
+		if err := s.RestoreBackup(backup.NewS3(client, uuid, s.ID(), ""), res.Body); err != nil {
 			logger.WithField("error", errors.WithStack(err)).Error("failed to restore remote S3 backup to server")
 		}
 		s.Events().Publish(server.DaemonMessageEvent, "Completed server restoration from S3 backup.")
@@ -224,7 +223,7 @@ func deleteServerBackup(c *gin.Context) {
 	if !ok {
 		return
 	}
-	b, _, err := backup.LocateLocal(middleware.ExtractApiClient(c), backupUuid)
+	b, _, err := backup.LocateLocal(middleware.ExtractApiClient(c), backupUuid, middleware.ExtractServer(c).ID())
 	if err != nil {
 		// Just return from the function at this point if the backup was not located.
 		if errors.Is(err, os.ErrNotExist) {

--- a/server/backup/backup.go
+++ b/server/backup/backup.go
@@ -123,14 +123,14 @@ func (b *Backup) Path() string {
 	if err != nil {
 		identifier = path.Base(b.Identifier())
 	}
-	return path.Join(config.Get().System.BackupDirectory, identifier+".tar.gz")
+	return path.Join(config.Get().System.BackupDirectory, b.ServerId(), identifier+".tar.gz")
 }
 
 // Size returns the size of the generated backup.
 func (b *Backup) Size() (int64, error) {
 	if err := b.validateIdentifier(); err != nil {
 		return 0, err
-	}	
+	}
 	st, err := os.Stat(b.Path())
 	if err != nil {
 		return 0, err
@@ -143,7 +143,7 @@ func (b *Backup) Size() (int64, error) {
 func (b *Backup) Checksum() ([]byte, error) {
 	if err := b.validateIdentifier(); err != nil {
 		return nil, err
-	}	
+	}
 	h := sha1.New()
 
 	f, err := os.Open(b.Path())

--- a/server/backup/backup_local.go
+++ b/server/backup/backup_local.go
@@ -21,21 +21,22 @@ type LocalBackup struct {
 
 var _ BackupInterface = (*LocalBackup)(nil)
 
-func NewLocal(client remote.Client, uuid string, ignore string) *LocalBackup {
+func NewLocal(client remote.Client, uuid string, suuid string, ignore string) *LocalBackup {
 	return &LocalBackup{
 		Backup{
-			client:  client,
-			Uuid:    uuid,
-			Ignore:  ignore,
-			adapter: LocalBackupAdapter,
+			client:     client,
+			Uuid:       uuid,
+			ServerUuid: suuid,
+			Ignore:     ignore,
+			adapter:    LocalBackupAdapter,
 		},
 	}
 }
 
 // LocateLocal finds the backup for a server and returns the local path. This
 // will obviously only work if the backup was created as a local backup.
-func LocateLocal(client remote.Client, uuid string) (*LocalBackup, os.FileInfo, error) {
-	b := NewLocal(client, uuid, "")
+func LocateLocal(client remote.Client, uuid string, suuid string) (*LocalBackup, os.FileInfo, error) {
+	b := NewLocal(client, uuid, suuid, "")
 	if err := b.validateIdentifier(); err != nil {
 		return nil, nil, err
 	}
@@ -55,7 +56,7 @@ func LocateLocal(client remote.Client, uuid string) (*LocalBackup, os.FileInfo, 
 func (b *LocalBackup) Remove() error {
 	if err := b.validateIdentifier(); err != nil {
 		return err
-	}	
+	}
 	err := os.Remove(b.Path())
 	if err != nil {
 		return err
@@ -83,7 +84,7 @@ func (b *LocalBackup) WithLogContext(c map[string]interface{}) {
 func (b *LocalBackup) Generate(ctx context.Context, fsys *filesystem.Filesystem, ignore string) (*ArchiveDetails, error) {
 	if err := b.validateIdentifier(); err != nil {
 		return nil, err
-	}	
+	}
 	a := &filesystem.Archive{
 		Filesystem: fsys,
 		Ignore:     ignore,
@@ -113,7 +114,7 @@ func (b *LocalBackup) Generate(ctx context.Context, fsys *filesystem.Filesystem,
 func (b *LocalBackup) Restore(ctx context.Context, _ io.Reader, callback RestoreCallback) error {
 	if err := b.validateIdentifier(); err != nil {
 		return err
-	}	
+	}
 	f, err := os.Open(b.Path())
 	if err != nil {
 		return err

--- a/server/backup/backup_s3.go
+++ b/server/backup/backup_s3.go
@@ -26,13 +26,14 @@ type S3Backup struct {
 
 var _ BackupInterface = (*S3Backup)(nil)
 
-func NewS3(client remote.Client, uuid string, ignore string) *S3Backup {
+func NewS3(client remote.Client, uuid string, suuid string, ignore string) *S3Backup {
 	return &S3Backup{
 		Backup{
-			client:  client,
-			Uuid:    uuid,
-			Ignore:  ignore,
-			adapter: S3BackupAdapter,
+			client:     client,
+			Uuid:       uuid,
+			ServerUuid: suuid,
+			Ignore:     ignore,
+			adapter:    S3BackupAdapter,
 		},
 	}
 }
@@ -41,7 +42,7 @@ func NewS3(client remote.Client, uuid string, ignore string) *S3Backup {
 func (s *S3Backup) Remove() error {
 	if err := s.validateIdentifier(); err != nil {
 		return err
-	}	
+	}
 	return os.Remove(s.Path())
 }
 
@@ -69,7 +70,7 @@ func (s *S3Backup) Generate(ctx context.Context, fsys *filesystem.Filesystem, ig
 		if err != nil {
 			return nil, err
 		}
-	}	
+	}
 	if err := a.Create(ctx, s.Path()); err != nil {
 		return nil, err
 	}

--- a/server/backup/backup_test.go
+++ b/server/backup/backup_test.go
@@ -15,10 +15,10 @@ import (
 func TestBackupGenerateRequiresUuidIdentifier(t *testing.T) {
 	tests := map[string]func(string) BackupInterface{
 		"local": func(identifier string) BackupInterface {
-			return NewLocal(nil, identifier, "")
+			return NewLocal(nil, identifier, "ce6ee345-6729-4aed-8fed-c866c535a69d", "")
 		},
 		"s3": func(identifier string) BackupInterface {
-			return NewS3(nil, identifier, "")
+			return NewS3(nil, identifier, "ce6ee345-6729-4aed-8fed-c866c535a69d", "")
 		},
 	}
 
@@ -43,7 +43,7 @@ func TestBackupPathUsesBackupDirectory(t *testing.T) {
 		"../target/archive",
 		"nested/archive",
 	} {
-		b := NewLocal(nil, identifier, "")
+		b := NewLocal(nil, identifier, "ce6ee345-6729-4aed-8fed-c866c535a69d", "")
 		rel, err := filepath.Rel(backupDir, b.Path())
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
# Changes

- Fix that server backups were all placed in the same directory after the July upstream changed were merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup handling by separating backup files by server.
  * Backup creation, restoration, deletion, and downloads now consistently target the correct server-specific backup location.
  * Applies to both local and S3-backed backups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->